### PR TITLE
perf: fix server slowness - Redis backdoor, missing indexes, correlated subquery

### DIFF
--- a/app/Http/Controllers/DashboardInfureController.php
+++ b/app/Http/Controllers/DashboardInfureController.php
@@ -365,22 +365,25 @@ class DashboardInfureController extends Controller
                     SELECT mac.id AS machine_id, 1 AS period_ke, COALESCE(SUM(EXTRACT(EPOCH FROM tjm.work_hour))/3600.0,0) AS work_hour_h
                     FROM tdjamkerjamesin tjm
                     INNER JOIN msmachine mac ON mac.id = tjm.machine_id
+                    INNER JOIN msworkingshift mws ON mws.id = tjm.work_shift
                     WHERE mac.department_id = :factory
-                        AND tjm.working_date + (SELECT work_hour_from FROM msworkingshift WHERE id = tjm.work_shift) BETWEEN :startMonth AND :firstPeriod
+                        AND tjm.working_date + mws.work_hour_from BETWEEN :startMonth AND :firstPeriod
                     GROUP BY mac.id
                     UNION ALL
                     SELECT mac.id AS machine_id, 2 AS period_ke, COALESCE(SUM(EXTRACT(EPOCH FROM tjm.work_hour))/3600.0,0) AS work_hour_h
                     FROM tdjamkerjamesin tjm
                     INNER JOIN msmachine mac ON mac.id = tjm.machine_id
+                    INNER JOIN msworkingshift mws ON mws.id = tjm.work_shift
                     WHERE mac.department_id = :factory
-                        AND tjm.working_date + (SELECT work_hour_from FROM msworkingshift WHERE id = tjm.work_shift) BETWEEN :firstPeriodPlus AND :secondPeriod
+                        AND tjm.working_date + mws.work_hour_from BETWEEN :firstPeriodPlus AND :secondPeriod
                     GROUP BY mac.id
                     UNION ALL
                     SELECT mac.id AS machine_id, 3 AS period_ke, COALESCE(SUM(EXTRACT(EPOCH FROM tjm.work_hour))/3600.0,0) AS work_hour_h
                     FROM tdjamkerjamesin tjm
                     INNER JOIN msmachine mac ON mac.id = tjm.machine_id
+                    INNER JOIN msworkingshift mws ON mws.id = tjm.work_shift
                     WHERE mac.department_id = :factory
-                        AND tjm.working_date + (SELECT work_hour_from FROM msworkingshift WHERE id = tjm.work_shift) BETWEEN :secondPeriodPlus AND :endMonth
+                        AND tjm.working_date + mws.work_hour_from BETWEEN :secondPeriodPlus AND :endMonth
                     GROUP BY mac.id
                 ) tjm_agg ON mac.id = tjm_agg.machine_id AND tjm_agg.period_ke = periods.period_ke
                 WHERE mac.department_id = :factory

--- a/app/Http/Controllers/DashboardSeitaiController.php
+++ b/app/Http/Controllers/DashboardSeitaiController.php
@@ -376,22 +376,25 @@ class DashboardSeitaiController extends Controller
                 SELECT mac.id AS machine_id, 1 AS period_ke, COALESCE(SUM(EXTRACT(EPOCH FROM tjm.work_hour))/3600.0,0) AS work_hour_h
                 FROM tdjamkerjamesin tjm
                 INNER JOIN msmachine mac ON mac.id = tjm.machine_id
+                INNER JOIN msworkingshift mws ON mws.id = tjm.work_shift
                 WHERE mac.department_id = :factory
-                    AND tjm.working_date + (SELECT work_hour_from FROM msworkingshift WHERE id = tjm.work_shift) BETWEEN :startMonth AND :firstPeriod
+                    AND tjm.working_date + mws.work_hour_from BETWEEN :startMonth AND :firstPeriod
                 GROUP BY mac.id
                 UNION ALL
                 SELECT mac.id AS machine_id, 2 AS period_ke, COALESCE(SUM(EXTRACT(EPOCH FROM tjm.work_hour))/3600.0,0) AS work_hour_h
                 FROM tdjamkerjamesin tjm
                 INNER JOIN msmachine mac ON mac.id = tjm.machine_id
+                INNER JOIN msworkingshift mws ON mws.id = tjm.work_shift
                 WHERE mac.department_id = :factory
-                    AND tjm.working_date + (SELECT work_hour_from FROM msworkingshift WHERE id = tjm.work_shift) BETWEEN :firstPeriodPlus AND :secondPeriod
+                    AND tjm.working_date + mws.work_hour_from BETWEEN :firstPeriodPlus AND :secondPeriod
                 GROUP BY mac.id
                 UNION ALL
                 SELECT mac.id AS machine_id, 3 AS period_ke, COALESCE(SUM(EXTRACT(EPOCH FROM tjm.work_hour))/3600.0,0) AS work_hour_h
                 FROM tdjamkerjamesin tjm
                 INNER JOIN msmachine mac ON mac.id = tjm.machine_id
+                INNER JOIN msworkingshift mws ON mws.id = tjm.work_shift
                 WHERE mac.department_id = :factory
-                    AND tjm.working_date + (SELECT work_hour_from FROM msworkingshift WHERE id = tjm.work_shift) BETWEEN :secondPeriodPlus AND :endMonth
+                    AND tjm.working_date + mws.work_hour_from BETWEEN :secondPeriodPlus AND :endMonth
                 GROUP BY mac.id
             ) tjm_agg ON mac.id = tjm_agg.machine_id AND tjm_agg.period_ke = periods.period_ke
             WHERE mac.department_id = :factory


### PR DESCRIPTION
## Summary

Investigasi dan perbaikan menyeluruh atas kelambatan aplikasi fukusuke-v2 yang dilaporkan. Ditemukan 3 root cause utama yang sudah diperbaiki.

## Root Cause & Fixes

### 🔴 Security: Redis Backdoor (Sisa Crypto Miner)
- **Masalah**: Attacker mengubah config Redis — `dir=/var/www/html`, `dbfilename=shell.php` — agar dump RDB ditulis sebagai PHP webshell di web root. Akibatnya seluruh Redis write diblokir (`stop-writes-on-bgsave-error`), termasuk cache dan session app.
- **Fix (server)**: Reset `dir=/var/lib/redis`, `dbfilename=dump.rdb`, hapus `shell.php`, set `requirepass` sesuai `.env`.

### 🔴 Performance: Correlated Subquery pada 677K-row Table
- **Masalah**: Query `total-produksi-per-bulan` dan `total-produksi-per-bulan` (Infure) menggunakan correlated subquery dalam 3 blok UNION ALL:
  ```sql
  AND tjm.working_date + (SELECT work_hour_from FROM msworkingshift WHERE id = tjm.work_shift)
  ```
  Subquery ini dieksekusi **ulang untuk setiap baris** `tdjamkerjamesin` (677K rows × 3 = ~2 juta eksekusi). Waktu query: **1348ms**.
- **Fix**: Ganti dengan `INNER JOIN msworkingshift mws ON mws.id = tjm.work_shift`. Hasil: **~100ms (~13x speedup)**.

### 🟠 Performance: Missing Database Indexes
- **Masalah**: 6 index kritis tidak ada di tabel utama (504K–677K rows).
- **Fix (server, applied via `CREATE INDEX CONCURRENTLY`):**
  | Index | Tabel | Dampak |
  |-------|-------|--------|
  | `(machine_id, production_date)` | `tdproduct_goods` | Composite index untuk JOIN condition paling umum |
  | `(product_goods_id)` | `tdproduct_goods_loss` | FK tanpa index → seq scan per 504K rows |
  | `(product_goods_id, loss_seitai_id)` | `tdproduct_goods_loss` | Covering index untuk EXISTS subquery |
  | `(department_id, status)` | `msmachine` | Filter di semua query dashboard |
  | `(loss_class_id)` | `mslossseitai` | Filter `IN (10,11,12,13)` |
  | `(working_date, machine_id)` | `tdjamkerjamesin` | Date range queries pada 677K rows |
  
  Query `top-loss-per-mesin`: **126ms → 0.47ms (264x speedup)**.

## Additional Server Fixes (tidak ada perubahan code)

- `CACHE_DRIVER`: `file` → `redis` (cache ke memory, bukan disk)
- `SESSION_DRIVER`: `file` → `redis`
- `REDIS_HOST`: `192.168.100.100` → `127.0.0.1`
- `APP_ENV`: `local` → `production`
- Jalankan `php artisan config:cache`, `route:cache`, `view:cache`
- Fix storage permissions

## Files Changed

- `app/Http/Controllers/DashboardSeitaiController.php` — correlated subquery → JOIN
- `app/Http/Controllers/DashboardInfureController.php` — correlated subquery → JOIN
- `resources/views/layouts/vendor-scripts.blade.php` — hapus double loading app.js
- `README.md` — update dokumentasi Bluetooth Printer feature

## Test Plan

- [ ] Buka halaman `/nippo-seitai` — pastikan dashboard load < 3 detik
- [ ] Buka halaman `/general-report` — pastikan tidak timeout
- [ ] Buka halaman `/api/dashboard-seitai/total-produksi-per-bulan` — response < 300ms
- [ ] Login/logout berfungsi normal (session via Redis)
- [ ] Cache berfungsi (cek `redis-cli -a '<pass>' dbsize` bertambah setelah request)

🤖 Generated with [Claude Code](https://claude.com/claude-code)