### PR TITLE
perf: nippo-seitai lazy loading via wire:init + security webshell cleanup

### DIFF
--- a/app/Http/Livewire/NippoSeitai/NippoSeitaiController.php
+++ b/app/Http/Livewire/NippoSeitai/NippoSeitaiController.php
@@ -3,7 +3,6 @@
 namespace App\Http\Livewire\NippoSeitai;
 
 use Livewire\Component;
-use Livewire\Attributes\Lazy;
 use Carbon\Carbon;
 use App\Models\MsProduct;
 use App\Models\MsBuyer;
@@ -16,22 +15,16 @@ use Livewire\WithoutUrlPagination;
 use Livewire\Attributes\Session;
 use App\Traits\HandlesHeavyJob;
 
-#[Lazy]
 class NippoSeitaiController extends Component
 {
     use HandlesHeavyJob;
     use WithPagination, WithoutUrlPagination;
 
-    public function placeholder(): string
+    public bool $isLoaded = false;
+
+    public function loadData(): void
     {
-        return <<<HTML
-        <div class="card">
-            <div class="card-body py-5 text-center">
-                <div class="spinner-border text-primary me-2" role="status" style="width:2rem;height:2rem;"></div>
-                <span class="text-muted fs-5">Memuat data nippo seitai...</span>
-            </div>
-        </div>
-        HTML;
+        $this->isLoaded = true;
     }
 
     protected $paginationTheme = 'bootstrap';
@@ -125,6 +118,23 @@ class NippoSeitaiController extends Component
 
     public function render()
     {
+        // Return empty paginator immediately on first render (wire:init will trigger loadData)
+        if (!$this->isLoaded) {
+            $products = Cache::remember('ms_products_seitai', 3600, fn() =>
+                MsProduct::select(['id', 'name', 'code'])->orderBy('code')->get()
+            );
+            $machine = Cache::remember('ms_machines_seitai', 3600, fn() =>
+                MsMachine::select(['id', 'machineno'])
+                    ->where('machineno', 'LIKE', '00S%')
+                    ->orderBy('machineno')->get()
+            );
+            return view('livewire.nippo-seitai.nippo-seitai', [
+                'data'     => new \Illuminate\Pagination\LengthAwarePaginator([], 0, $this->perPage),
+                'products' => $products,
+                'machine'  => $machine,
+            ])->extends('layouts.master');
+        }
+
         $tglAwal  = Carbon::parse($this->tglMasuk)->format('d-m-Y 00:00:00');
         $tglAkhir = Carbon::parse($this->tglKeluar)->format('d-m-Y 23:59:59');
 

--- a/app/Http/Livewire/NippoSeitai/NippoSeitaiController.php
+++ b/app/Http/Livewire/NippoSeitai/NippoSeitaiController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Livewire\NippoSeitai;
 
 use Livewire\Component;
+use Livewire\Attributes\Lazy;
 use Carbon\Carbon;
 use App\Models\MsProduct;
 use App\Models\MsBuyer;
@@ -15,10 +16,23 @@ use Livewire\WithoutUrlPagination;
 use Livewire\Attributes\Session;
 use App\Traits\HandlesHeavyJob;
 
+#[Lazy]
 class NippoSeitaiController extends Component
 {
     use HandlesHeavyJob;
     use WithPagination, WithoutUrlPagination;
+
+    public function placeholder(): string
+    {
+        return <<<HTML
+        <div class="card">
+            <div class="card-body py-5 text-center">
+                <div class="spinner-border text-primary me-2" role="status" style="width:2rem;height:2rem;"></div>
+                <span class="text-muted fs-5">Memuat data nippo seitai...</span>
+            </div>
+        </div>
+        HTML;
+    }
 
     protected $paginationTheme = 'bootstrap';
 

--- a/resources/views/livewire/nippo-seitai/nippo-seitai.blade.php
+++ b/resources/views/livewire/nippo-seitai/nippo-seitai.blade.php
@@ -1,4 +1,14 @@
-<div>
+<div wire:init="loadData">
+    {{-- Skeleton: tampil saat data belum dimuat (isLoaded = false) --}}
+    @if(!$isLoaded)
+    <div class="card">
+        <div class="card-body py-5 text-center">
+            <div class="spinner-border text-primary me-2" role="status" style="width:2.5rem;height:2.5rem;"></div>
+            <p class="text-muted mt-3 mb-0 fs-5">Memuat data nippo seitai...</p>
+            <p class="text-muted small">Harap tunggu sebentar</p>
+        </div>
+    </div>
+    @else
     {{-- Loading bar untuk Livewire request (filter, sort, paginate) --}}
     <div wire:loading.delay class="position-fixed" style="top:0;left:0;width:100%;height:3px;background:linear-gradient(90deg,#0ab39c,#405189,#0ab39c);background-size:200%;animation:nippo-bar-slide 1.5s linear infinite;z-index:99999;"></div>
     {{-- Overlay untuk navigasi full-page (edit, add) --}}
@@ -414,3 +424,5 @@
         });
     </script>
 @endscript
+@endif
+


### PR DESCRIPTION
## Summary

- Lazy loading untuk nippo-seitai agar halaman tidak blank 8 detik
- Cleanup webshells sisa crypto miner yang ditemukan di server

## Changes

### Fix: Livewire wire:init lazy loading — nippo-seitai
- Halaman nippo-seitai sebelumnya blank ~8 detik karena query berat dijalankan sebelum HTML dikembalikan
- Solusi: gunakan `wire:init="loadData"` — render pertama langsung kembali dengan skeleton spinner, query berat dijalankan setelah HTML diterima browser
- `isLoaded = false` → render kosong + spinner | `isLoaded = true` → render data penuh
- Skeleton ditampilkan via `@if(!$isLoaded)` di blade

### Security: Webshell cleanup (dilakukan langsung di server)
Ditemukan dan dihapus dari server (sisa serangan crypto miner sebelumnya):
- `public/78k.php`, `public/kozlakola.php`, `public/okwokwaokw.php` — PHP eval webshells
- `public/preLinkInit.php`, `public/preLoaderInit.php` — backdoor scripts
- `public/asset/image/mainhack.php` — webshell tersembunyi
- `public/asset/report/mainhack.php`, `mainhack (1).php` — webshells
- `public/katanuki/.../mainhack.php` (2 file) — webshells tersembunyi
- `index.php` (root level) — **C2 beacon** konek ke `192.151.158.98/z60523_7/`
- `public/261b68/`, `public/67e79/` — direktori mencurigakan

## Test Plan

- [ ] Buka `/nippo-seitai` — pastikan spinner muncul langsung (<1 detik)
- [ ] Data tabel muncul setelah ~8 detik (background load)
- [ ] Filter, sort, paginate tetap berfungsi normal setelah data loaded
- [ ] Tidak ada PHP error 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)