### PR TITLE
fix: restore JS init on lazy-loaded pages + native date inputs

### DIFF
--- a/app/Http/Livewire/Kenpin/KenpinInfureController.php
+++ b/app/Http/Livewire/Kenpin/KenpinInfureController.php
@@ -41,11 +41,11 @@ class KenpinInfureController extends Component
 
     public function mount()
     {
-        if (empty($this->tglMasuk)) {
-            $this->tglMasuk = Carbon::now()->format('d-m-Y');
+        if (empty($this->tglMasuk) || !preg_match('/^\d{4}-\d{2}-\d{2}$/', $this->tglMasuk)) {
+            $this->tglMasuk = Carbon::now()->format('Y-m-d');
         }
-        if (empty($this->tglKeluar)) {
-            $this->tglKeluar = Carbon::now()->format('d-m-Y');
+        if (empty($this->tglKeluar) || !preg_match('/^\d{4}-\d{2}-\d{2}$/', $this->tglKeluar)) {
+            $this->tglKeluar = Carbon::now()->format('Y-m-d');
         }
         if (empty($this->sortingTable)) {
             $this->sortingTable = [[1, 'asc']];

--- a/app/Http/Livewire/Kenpin/KenpinSeitaiController.php
+++ b/app/Http/Livewire/Kenpin/KenpinSeitaiController.php
@@ -43,11 +43,11 @@ class KenpinSeitaiController extends Component
 
     public function mount()
     {
-        if (empty($this->tglMasuk)) {
-            $this->tglMasuk = Carbon::now()->format('d-m-Y');
+        if (empty($this->tglMasuk) || !preg_match('/^\d{4}-\d{2}-\d{2}$/', $this->tglMasuk)) {
+            $this->tglMasuk = Carbon::now()->format('Y-m-d');
         }
-        if (empty($this->tglKeluar)) {
-            $this->tglKeluar = Carbon::now()->format('d-m-Y');
+        if (empty($this->tglKeluar) || !preg_match('/^\d{4}-\d{2}-\d{2}$/', $this->tglKeluar)) {
+            $this->tglKeluar = Carbon::now()->format('Y-m-d');
         }
         if (empty($this->sortingTable)) {
             $this->sortingTable = [[1, 'asc']];

--- a/app/Http/Livewire/NippoInfure/LossInfureController.php
+++ b/app/Http/Livewire/NippoInfure/LossInfureController.php
@@ -51,11 +51,11 @@ class LossInfureController extends Component
         if (empty($this->transaksi)) {
             $this->transaksi = 1;
         }
-        if (empty($this->tglMasuk)) {
-            $this->tglMasuk = Carbon::now()->format('d M Y');
+        if (empty($this->tglMasuk) || !preg_match('/^\d{4}-\d{2}-\d{2}$/', $this->tglMasuk)) {
+            $this->tglMasuk = Carbon::now()->format('Y-m-d');
         }
-        if (empty($this->tglKeluar)) {
-            $this->tglKeluar = Carbon::now()->format('d M Y');
+        if (empty($this->tglKeluar) || !preg_match('/^\d{4}-\d{2}-\d{2}$/', $this->tglKeluar)) {
+            $this->tglKeluar = Carbon::now()->format('Y-m-d');
         }
         if (empty($this->sortingTable)) {
             $this->sortingTable = [[1, 'asc']];

--- a/app/Http/Livewire/NippoInfure/NippoInfureController.php
+++ b/app/Http/Livewire/NippoInfure/NippoInfureController.php
@@ -66,11 +66,11 @@ class NippoInfureController extends Component
         if (empty($this->transaksi)) {
             $this->transaksi = 1;
         }
-        if (empty($this->tglMasuk)) {
-            $this->tglMasuk = Carbon::now()->format('d M Y');
+        if (empty($this->tglMasuk) || !preg_match('/^\d{4}-\d{2}-\d{2}$/', $this->tglMasuk)) {
+            $this->tglMasuk = Carbon::now()->format('Y-m-d');
         }
-        if (empty($this->tglKeluar)) {
-            $this->tglKeluar = Carbon::now()->format('d M Y');
+        if (empty($this->tglKeluar) || !preg_match('/^\d{4}-\d{2}-\d{2}$/', $this->tglKeluar)) {
+            $this->tglKeluar = Carbon::now()->format('Y-m-d');
         }
     }
 

--- a/app/Http/Livewire/NippoSeitai/LossSeitaiController.php
+++ b/app/Http/Livewire/NippoSeitai/LossSeitaiController.php
@@ -55,11 +55,11 @@ class LossSeitaiController extends Component
         if (empty($this->transaksi)) {
             $this->transaksi = 1;
         }
-        if (empty($this->tglMasuk)) {
-            $this->tglMasuk = Carbon::now()->format('d M Y');
+        if (empty($this->tglMasuk) || !preg_match('/^\d{4}-\d{2}-\d{2}$/', $this->tglMasuk)) {
+            $this->tglMasuk = Carbon::now()->format('Y-m-d');
         }
-        if (empty($this->tglKeluar)) {
-            $this->tglKeluar = Carbon::now()->format('d M Y');
+        if (empty($this->tglKeluar) || !preg_match('/^\d{4}-\d{2}-\d{2}$/', $this->tglKeluar)) {
+            $this->tglKeluar = Carbon::now()->format('Y-m-d');
         }
         if (empty($this->sortingTable)) {
             $this->sortingTable = [[1, 'asc']];

--- a/app/Http/Livewire/NippoSeitai/NippoSeitaiController.php
+++ b/app/Http/Livewire/NippoSeitai/NippoSeitaiController.php
@@ -52,8 +52,8 @@ class NippoSeitaiController extends Component
         if (is_array($this->status))    { $this->status    = $this->status['value']    ?? null; }
 
         if (empty($this->transaksi)) { $this->transaksi = 1; }
-        if (empty($this->tglMasuk))  { $this->tglMasuk  = Carbon::now()->format('d M Y'); }
-        if (empty($this->tglKeluar)) { $this->tglKeluar = Carbon::now()->format('d M Y'); }
+        if (empty($this->tglMasuk)  || !preg_match('/^\d{4}-\d{2}-\d{2}$/', $this->tglMasuk))  { $this->tglMasuk  = Carbon::now()->format('Y-m-d'); }
+        if (empty($this->tglKeluar) || !preg_match('/^\d{4}-\d{2}-\d{2}$/', $this->tglKeluar)) { $this->tglKeluar = Carbon::now()->format('Y-m-d'); }
     }
 
     protected function shouldForgetSession()

--- a/app/Http/Livewire/OrderLpkController.php
+++ b/app/Http/Livewire/OrderLpkController.php
@@ -69,11 +69,11 @@ class OrderLpkController extends Component
     {
         $this->shouldForgetSession();
 
-        if (empty($this->tglMasuk)) {
-            $this->tglMasuk = Carbon::now()->format('d M Y');
+        if (empty($this->tglMasuk) || !preg_match('/^\d{4}-\d{2}-\d{2}$/', $this->tglMasuk)) {
+            $this->tglMasuk = Carbon::now()->format('Y-m-d');
         }
-        if (empty($this->tglKeluar)) {
-            $this->tglKeluar = Carbon::now()->format('d M Y');
+        if (empty($this->tglKeluar) || !preg_match('/^\d{4}-\d{2}-\d{2}$/', $this->tglKeluar)) {
+            $this->tglKeluar = Carbon::now()->format('Y-m-d');
         }
         if (empty($this->transaksi)) {
             $this->transaksi = 1;

--- a/resources/views/livewire/kenpin/kenpin-infure.blade.php
+++ b/resources/views/livewire/kenpin/kenpin-infure.blade.php
@@ -19,17 +19,10 @@
                         <div class="col-12">
                             <div class="form-group">
                                 <div class="input-group">
-                                    <input wire:model.defer="tglMasuk" type="text" class="form-control"
-                                        style="padding:0.44rem" data-provider="flatpickr" data-date-format="d-m-Y">
-                                    <span class="input-group-text py-0">
-                                        <i class="ri-calendar-event-fill fs-4"></i>
-                                    </span>
-
-                                    <input wire:model.defer="tglKeluar" type="text" class="form-control"
-                                        style="padding:0.44rem" data-provider="flatpickr" data-date-format="d-m-Y">
-                                    <span class="input-group-text py-0">
-                                        <i class="ri-calendar-event-fill fs-4"></i>
-                                    </span>
+                                    <input wire:model.defer="tglMasuk" type="date" class="form-control"
+                                        style="padding:0.44rem">
+                                    <input wire:model.defer="tglKeluar" type="date" class="form-control"
+                                        style="padding:0.44rem">
                                 </div>
                             </div>
                         </div>
@@ -332,9 +325,28 @@
         </table>
     </div>
 </div>
+@endif
 
 @script
     <script>
+        document.addEventListener('livewire:initialized', function() {
+            function initChoices() {
+                if (typeof Choices === 'undefined') return;
+                document.querySelectorAll('[data-choices]').forEach(function(item) {
+                    if (item.parentElement && item.parentElement.classList.contains('choices')) return;
+                    var opts = { allowHTML: true, shouldSort: false };
+                    if (item.hasAttribute('data-choices-removeItem')) { opts.removeItems = true; opts.removeItemButton = true; }
+                    if (item.hasAttribute('data-choices-search-field-label')) opts.searchEnabled = true;
+                    if (item.hasAttribute('data-choices-exact-match')) opts.fuseOptions = { threshold: 0 };
+                    new Choices(item, opts);
+                });
+            }
+            initChoices();
+            Livewire.hook('morph', ({ el, component }) => {
+                setTimeout(function() { initChoices(); }, 100);
+            });
+        });
+
         // datatable
         // inisialisasi DataTable
         $wire.on('initDataTable', () => {
@@ -401,5 +413,4 @@
         }
     </script>
 @endscript
-@endif
 

--- a/resources/views/livewire/kenpin/kenpin-seitai.blade.php
+++ b/resources/views/livewire/kenpin/kenpin-seitai.blade.php
@@ -19,17 +19,10 @@
                         <div class="col-12">
                             <div class="form-group">
                                 <div class="input-group">
-                                    <input wire:model.defer="tglMasuk" type="text" class="form-control"
-                                        style="padding:0.44rem" data-provider="flatpickr" data-date-format="d-m-Y">
-                                    <span class="input-group-text py-0">
-                                        <i class="ri-calendar-event-fill fs-4"></i>
-                                    </span>
-
-                                    <input wire:model.defer="tglKeluar" type="text" class="form-control"
-                                        style="padding:0.44rem" data-provider="flatpickr" data-date-format="d-m-Y">
-                                    <span class="input-group-text py-0">
-                                        <i class="ri-calendar-event-fill fs-4"></i>
-                                    </span>
+                                    <input wire:model.defer="tglMasuk" type="date" class="form-control"
+                                        style="padding:0.44rem">
+                                    <input wire:model.defer="tglKeluar" type="date" class="form-control"
+                                        style="padding:0.44rem">
                                 </div>
                             </div>
                         </div>
@@ -313,9 +306,28 @@
         {{-- {{ $data->links(data: ['scrollTo' => false]) }} --}}
     </div>
 </div>
+@endif
 
 @script
     <script>
+        document.addEventListener('livewire:initialized', function() {
+            function initChoices() {
+                if (typeof Choices === 'undefined') return;
+                document.querySelectorAll('[data-choices]').forEach(function(item) {
+                    if (item.parentElement && item.parentElement.classList.contains('choices')) return;
+                    var opts = { allowHTML: true, shouldSort: false };
+                    if (item.hasAttribute('data-choices-removeItem')) { opts.removeItems = true; opts.removeItemButton = true; }
+                    if (item.hasAttribute('data-choices-search-field-label')) opts.searchEnabled = true;
+                    if (item.hasAttribute('data-choices-exact-match')) opts.fuseOptions = { threshold: 0 };
+                    new Choices(item, opts);
+                });
+            }
+            initChoices();
+            Livewire.hook('morph', ({ el, component }) => {
+                setTimeout(function() { initChoices(); }, 100);
+            });
+        });
+
         // datatable
         // inisialisasi DataTable
         $wire.on('initDataTable', () => {
@@ -382,5 +394,4 @@
         }
     </script>
 @endscript
-@endif
 

--- a/resources/views/livewire/nippo-infure/loss-infure.blade.php
+++ b/resources/views/livewire/nippo-infure/loss-infure.blade.php
@@ -25,17 +25,10 @@
                             <div class="col-9">
                                 <div class="form-group">
                                     <div class="input-group">
-                                        <input wire:model.defer="tglMasuk" type="text" class="form-control"
-                                            style="padding:0.44rem" data-provider="flatpickr" data-date-format="d M Y">
-                                        <span class="input-group-text py-0">
-                                            <i class="ri-calendar-event-fill fs-4"></i>
-                                        </span>
-
-                                        <input wire:model.defer="tglKeluar" type="text" class="form-control"
-                                            style="padding:0.44rem" data-provider="flatpickr" data-date-format="d M Y">
-                                        <span class="input-group-text py-0">
-                                            <i class="ri-calendar-event-fill fs-4"></i>
-                                        </span>
+                                        <input wire:model.defer="tglMasuk" type="date" class="form-control"
+                                            style="padding:0.44rem">
+                                        <input wire:model.defer="tglKeluar" type="date" class="form-control"
+                                            style="padding:0.44rem">
                                     </div>
                                 </div>
                             </div>
@@ -383,8 +376,28 @@
         }
     </style>
 </div>
+@endif
+
 @script
     <script>
+        document.addEventListener('livewire:initialized', function() {
+            function initChoices() {
+                if (typeof Choices === 'undefined') return;
+                document.querySelectorAll('[data-choices]').forEach(function(item) {
+                    if (item.parentElement && item.parentElement.classList.contains('choices')) return;
+                    var opts = { allowHTML: true, shouldSort: false };
+                    if (item.hasAttribute('data-choices-removeItem')) { opts.removeItems = true; opts.removeItemButton = true; }
+                    if (item.hasAttribute('data-choices-search-field-label')) opts.searchEnabled = true;
+                    if (item.hasAttribute('data-choices-exact-match')) opts.fuseOptions = { threshold: 0 };
+                    new Choices(item, opts);
+                });
+            }
+            initChoices();
+            Livewire.hook('morph', ({ el, component }) => {
+                setTimeout(function() { initChoices(); }, 100);
+            });
+        });
+
         $wire.on('redirectToPrint', (datas) => {
             var printUrl = '{{ route('report-nippo-infure') }}?tanggal=' + datas;
             window.open(printUrl, '_blank');
@@ -468,5 +481,4 @@
         }
     </script>
 @endscript
-@endif
 

--- a/resources/views/livewire/nippo-infure/nippo-infure.blade.php
+++ b/resources/views/livewire/nippo-infure/nippo-infure.blade.php
@@ -31,17 +31,10 @@
                             <div class="col-9">
                                 <div class="form-group">
                                     <div class="input-group">
-                                        <input wire:model.defer="tglMasuk" type="text" class="form-control"
-                                            style="padding:0.44rem" data-provider="flatpickr" data-date-format="d M Y">
-                                        <span class="input-group-text py-0">
-                                            <i class="ri-calendar-event-fill fs-4"></i>
-                                        </span>
-
-                                        <input wire:model.defer="tglKeluar" type="text" class="form-control"
-                                            style="padding:0.44rem" data-provider="flatpickr" data-date-format="d M Y">
-                                        <span class="input-group-text py-0">
-                                            <i class="ri-calendar-event-fill fs-4"></i>
-                                        </span>
+                                        <input wire:model.defer="tglMasuk" type="date" class="form-control"
+                                            style="padding:0.44rem">
+                                        <input wire:model.defer="tglKeluar" type="date" class="form-control"
+                                            style="padding:0.44rem">
                                     </div>
                                 </div>
                             </div>
@@ -350,6 +343,8 @@
         }
     </style>
 </div>
+@endif
+
 @script
     <script>
         $wire.on('redirectToPrint', (datas) => {
@@ -420,5 +415,4 @@
         });
     </script>
 @endscript
-@endif
 

--- a/resources/views/livewire/nippo-seitai/loss-seitai.blade.php
+++ b/resources/views/livewire/nippo-seitai/loss-seitai.blade.php
@@ -25,17 +25,10 @@
                         <div class="col-9">
                             <div class="form-group">
                                 <div class="input-group">
-                                    <input wire:model.defer="tglMasuk" type="text" class="form-control"
-                                        style="padding:0.44rem" data-provider="flatpickr" data-date-format="d M Y">
-                                    <span class="input-group-text py-0">
-                                        <i class="ri-calendar-event-fill fs-4"></i>
-                                    </span>
-
-                                    <input wire:model.defer="tglKeluar" type="text" class="form-control"
-                                        style="padding:0.44rem" data-provider="flatpickr" data-date-format="d M Y">
-                                    <span class="input-group-text py-0">
-                                        <i class="ri-calendar-event-fill fs-4"></i>
-                                    </span>
+                                    <input wire:model.defer="tglMasuk" type="date" class="form-control"
+                                        style="padding:0.44rem">
+                                    <input wire:model.defer="tglKeluar" type="date" class="form-control"
+                                        style="padding:0.44rem">
                                 </div>
                             </div>
                         </div>
@@ -360,9 +353,28 @@
         }
     </style>
 </div>
+@endif
 
 @script
     <script>
+        document.addEventListener('livewire:initialized', function() {
+            function initChoices() {
+                if (typeof Choices === 'undefined') return;
+                document.querySelectorAll('[data-choices]').forEach(function(item) {
+                    if (item.parentElement && item.parentElement.classList.contains('choices')) return;
+                    var opts = { allowHTML: true, shouldSort: false };
+                    if (item.hasAttribute('data-choices-removeItem')) { opts.removeItems = true; opts.removeItemButton = true; }
+                    if (item.hasAttribute('data-choices-search-field-label')) opts.searchEnabled = true;
+                    if (item.hasAttribute('data-choices-exact-match')) opts.fuseOptions = { threshold: 0 };
+                    new Choices(item, opts);
+                });
+            }
+            initChoices();
+            Livewire.hook('morph', ({ el, component }) => {
+                setTimeout(function() { initChoices(); }, 100);
+            });
+        });
+
         // datatable
         // inisialisasi DataTable
         $wire.on('initDataTable', () => {
@@ -442,5 +454,4 @@
         }
     </script>
 @endscript
-@endif
 

--- a/resources/views/livewire/nippo-seitai/nippo-seitai.blade.php
+++ b/resources/views/livewire/nippo-seitai/nippo-seitai.blade.php
@@ -33,16 +33,10 @@
                             </div>
                             <div class="col-9">
                                 <div class="input-group">
-                                    <input wire:model.defer="tglMasuk" type="text" class="form-control"
-                                        style="padding:0.44rem" data-provider="flatpickr" data-date-format="d M Y">
-                                    <span class="input-group-text py-0">
-                                        <i class="ri-calendar-event-fill fs-4"></i>
-                                    </span>
-                                    <input wire:model.defer="tglKeluar" type="text" class="form-control"
-                                        style="padding:0.44rem" data-provider="flatpickr" data-date-format="d M Y">
-                                    <span class="input-group-text py-0">
-                                        <i class="ri-calendar-event-fill fs-4"></i>
-                                    </span>
+                                    <input wire:model.defer="tglMasuk" type="date" class="form-control"
+                                        style="padding:0.44rem">
+                                    <input wire:model.defer="tglKeluar" type="date" class="form-control"
+                                        style="padding:0.44rem">
                                 </div>
                             </div>
                         </div>
@@ -359,6 +353,7 @@
         }
     </style>
 </div>
+@endif
 
 @script
     <script>
@@ -424,5 +419,4 @@
         });
     </script>
 @endscript
-@endif
 

--- a/resources/views/livewire/order-lpk/order-lpk.blade.php
+++ b/resources/views/livewire/order-lpk/order-lpk.blade.php
@@ -15,7 +15,7 @@
                     <label class="form-label text-muted fw-bold">Filter Tanggal</label>
                 </div>
                 <div class="col-12 col-lg-9 mb-1">
-                    <div class="form-group" wire:ignore>
+                    <div class="form-group">
                         <div class="input-group">
                             <div class="col-12 col-sm-3">
                                 <select class="form-select mb-2 mb-sm-0" style="padding:0.44rem" wire:model.defer="transaksi">
@@ -25,21 +25,10 @@
                             </div>
                             <div class="col-12 col-sm-9">
                                 <div class="d-flex flex-column flex-sm-row gap-2">
-                                    <div class="input-group">
-                                        <input wire:model.defer="tglMasuk" type="text" class="form-control"
-                                            style="padding:0.44rem" data-provider="flatpickr" data-date-format="d M Y">
-                                        <span class="input-group-text py-0">
-                                            <i class="ri-calendar-event-fill fs-4"></i>
-                                        </span>
-                                    </div>
-
-                                    <div class="input-group">
-                                        <input wire:model.defer="tglKeluar" type="text" class="form-control"
-                                            style="padding:0.44rem" data-provider="flatpickr" data-date-format="d M Y">
-                                        <span class="input-group-text py-0">
-                                            <i class="ri-calendar-event-fill fs-4"></i>
-                                        </span>
-                                    </div>
+                                    <input wire:model.defer="tglMasuk" type="date" class="form-control"
+                                        style="padding:0.44rem">
+                                    <input wire:model.defer="tglKeluar" type="date" class="form-control"
+                                        style="padding:0.44rem">
                                 </div>
                             </div>
                         </div>
@@ -333,6 +322,7 @@
         }
     </style>
 </div>
+@endif
 
 @script
     <script>
@@ -443,6 +433,18 @@
 
             selectProduct();
 
+            function initChoices() {
+                if (typeof Choices === 'undefined') return;
+                document.querySelectorAll('[data-choices]').forEach(function(item) {
+                    if (item.parentElement && item.parentElement.classList.contains('choices')) return;
+                    var opts = { allowHTML: true, shouldSort: false };
+                    if (item.hasAttribute('data-choices-removeItem')) { opts.removeItems = true; opts.removeItemButton = true; }
+                    if (item.hasAttribute('data-choices-search-field-label')) opts.searchEnabled = true;
+                    new Choices(item, opts);
+                });
+            }
+            initChoices();
+
             // Hook untuk Livewire v3
             Livewire.hook('morph', ({
                 el,
@@ -450,10 +452,10 @@
             }) => {
                 setTimeout(() => {
                     selectProduct();
+                    initChoices();
                 }, 100);
             });
         });
     </script>
 @endscript
-@endif
 


### PR DESCRIPTION
## Summary

- **flatpickr → `type=\"date\"`**: Flatpickr popup tidak muncul karena `plugins.js` init berjalan sebelum `wire:init` merender konten. Diganti input native `type=\"date\"` di 7 halaman lazy-loaded.
- **Format tanggal Y-m-d**: Default format controller diubah ke ISO 8601 (`Y-m-d`), ditambah guard regex untuk reset nilai session lama (`d M Y` / `d-m-Y`) yang tersimpan dari versi sebelumnya.
- **@script dipindah keluar @else**: Semua `@script`/`@endscript` yang sebelumnya ada di dalam `@else` (karena lazy loading wrapper) dipindah ke luar `@if/@else/@endif`. Root cause: `livewire:initialized` sudah fire saat `@script` baru dirender, sehingga Select2 / Choices.js / DataTable tidak pernah terdaftar.
- **initChoices()**: Ditambah ke pages yang pakai `data-choices` (loss-seitai, loss-infure, kenpin-infure, kenpin-seitai, order-lpk) menggunakan `livewire:initialized` + morph hook.

**Pages terdampak:** nippo-seitai, nippo-infure, loss-seitai, loss-infure, kenpin-infure, kenpin-seitai, order-lpk

## Test plan

- [ ] Buka setiap halaman — spinner muncul < 1 detik, data load otomatis
- [ ] Filter tanggal: input `type=\"date\"` tampil dengan nilai default hari ini
- [ ] Dropdown product/machine/buyer/status: Select2 / Choices.js tampil normal
- [ ] DataTable: sorting, searching, column toggle berfungsi setelah data load
- [ ] Filter → klik tombol Filter → data berubah sesuai filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)