### PR TITLE
refactor(jam-kerja): migrate Infure & Seitai to server-side pagination

### DIFF
--- a/app/Http/Livewire/JamKerja/InfureJamKerjaController.php
+++ b/app/Http/Livewire/JamKerja/InfureJamKerjaController.php
@@ -14,26 +14,34 @@ use App\Models\TdJamKerjaMesin;
 use Carbon\Carbon;
 use Livewire\Component;
 use App\Traits\HandlesHeavyJob;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Livewire\WithPagination;
 use Livewire\WithoutUrlPagination;
 use Livewire\Attributes\Session;
-use PhpParser\Node\Expr\FuncCall;
 use Illuminate\Support\Str;
 
 class InfureJamKerjaController extends Component
 {
-    use HandlesHeavyJob;
+    use HandlesHeavyJob, WithPagination, WithoutUrlPagination;
+
     protected $paginationTheme = 'bootstrap';
     protected $listeners = ['edit', 'delete'];
-    #[Session]
-    public $tglMasuk;
-    #[Session]
-    public $tglKeluar;
-    public $data = [];
+
+    public bool $isLoaded = false;
+
+    #[Session] public $tglMasuk;
+    #[Session] public $tglKeluar;
+    #[Session] public $transaksi;
+    #[Session] public $work_shift_filter;
+    #[Session] public $machine_id;
+    #[Session] public $searchTerm;
+    #[Session] public $perPage      = 10;
+    #[Session] public $sortColumn   = 'tdjkm.updated_on';
+    #[Session] public $sortDirection = 'desc';
+
     public $machinename;
     public $machineno;
-    public $machine;
     public $msemployee;
     public $employeeno;
     public $jamMatiMesinId;
@@ -43,157 +51,148 @@ class InfureJamKerjaController extends Component
     public $jamMatiTo;
     public $off_hour;
     public $dataJamMatiMesin = [];
-    #[Session]
-    public $transaksi;
     public $working_date;
     public $empname;
     public $work_shift;
-    #[Session]
-    public $work_shift_filter;
-    #[Session]
-    public $machine_id;
     public $employee_id;
     public $work_hour = '08:00';
-    public $totalOffHour = "00:00";
-    public $totalOnHour = "08:00";
+    public $totalOffHour = '00:00';
+    public $totalOnHour  = '08:00';
     public $on_hour;
     public $orderid;
-    public $workShift;
-    #[Session]
-    public $searchTerm;
     public $idDelete;
-    #[Session]
-    public $sortingTable;
-    public $isUpdatingSorting = false;
     public $jamMatiDataUpdated = false;
 
-    use WithPagination, WithoutUrlPagination;
+    public function sortBy(string $column): void
+    {
+        $allowed = [
+            'tdjkm.working_date', 'tdjkm.work_shift', 'msm.machineno',
+            'mse.employeeno', 'mse.empname', 'tdjkm.work_hour',
+            'tdjkm.off_hour', 'tdjkm.on_hour', 'tdjkm.updated_on', 'tdjkm.created_on',
+        ];
+        if (!in_array($column, $allowed)) return;
+        if ($this->sortColumn === $column) {
+            $this->sortDirection = $this->sortDirection === 'asc' ? 'desc' : 'asc';
+        } else {
+            $this->sortColumn    = $column;
+            $this->sortDirection = 'asc';
+        }
+        $this->resetPage();
+    }
 
-    public function mount()
+    public function loadData(): void
+    {
+        $this->isLoaded = true;
+    }
+
+    public function mount(): void
     {
         $this->shouldForgetSession();
 
-        if (empty($this->tglMasuk)) {
-            $this->tglMasuk = Carbon::now()->format('d-m-Y');
+        if (is_array($this->machine_id))        { $this->machine_id        = $this->machine_id['value']        ?? null; }
+        if (is_array($this->work_shift_filter)) { $this->work_shift_filter = $this->work_shift_filter['value'] ?? null; }
+
+        if (empty($this->tglMasuk) || !preg_match('/^\d{4}-\d{2}-\d{2}$/', $this->tglMasuk)) {
+            $this->tglMasuk = Carbon::now()->format('Y-m-d');
         }
-        if (empty($this->tglKeluar)) {
-            $this->tglKeluar = Carbon::now()->format('d-m-Y');
+        if (empty($this->tglKeluar) || !preg_match('/^\d{4}-\d{2}-\d{2}$/', $this->tglKeluar)) {
+            $this->tglKeluar = Carbon::now()->format('Y-m-d');
         }
         if (empty($this->transaksi)) {
             $this->transaksi = 1;
         }
-        $this->machine  = MsMachine::whereIn('department_id', departmentHelper::infurePabrikDepartment()->pluck('id'))->get();
-        $this->workShift  = MsWorkingShift::active()->get();
-        $this->working_date = Carbon::now()->format('d-m-Y');
-        if (empty($this->sortingTable)) {
-            $this->sortingTable = [[1, 'asc']];
-        }
-        $this->getData();
+
+        $this->working_date = Carbon::now()->format('Y-m-d');
     }
 
-    public function updateSortingTable($value)
+    protected function shouldForgetSession(): void
     {
-        $this->isUpdatingSorting = true;
-        $this->sortingTable = $value;
-
-        // Tidak skip render jika ada update data jam mati
-        if (!$this->jamMatiDataUpdated) {
-            $this->skipRender();
-        }
-
-        $this->isUpdatingSorting = false;
-    }
-
-    protected function shouldForgetSession()
-    {
-        $previousUrl = url()->previous();
-        $previousUrl = last(explode('/', $previousUrl));
-        if (!(Str::contains($previousUrl, 'infure-jam-kerja'))) {
-            $this->reset('tglMasuk', 'tglKeluar', 'transaksi', 'machine_id', 'work_shift_filter', 'searchTerm', 'sortingTable');
+        $previousUrl = last(explode('/', url()->previous()));
+        if (!Str::contains($previousUrl, 'infure-jam-kerja')) {
+            $this->reset('tglMasuk', 'tglKeluar', 'transaksi', 'machine_id', 'work_shift_filter', 'searchTerm', 'perPage', 'sortColumn', 'sortDirection');
         }
     }
 
-    public function search()
+    public function search(): void
     {
-        $this->getData();
+        $this->resetPage();
     }
 
-    public function showModalCreate()
+    public function showModalCreate(): void
     {
         if ($this->orderid) {
             $this->dataJamMatiMesin = [];
             $this->orderid = null;
             $this->resetInput();
         }
-        $this->working_date = Carbon::now()->format('d-m-Y');
+        $this->working_date = Carbon::now()->format('Y-m-d');
         $this->dispatch('showModalCreate');
         $this->jamMatiDataUpdated = true;
     }
 
-    public function edit($id)
+    public function edit($id): void
     {
         $this->jamMatiDataUpdated = true;
-        $item = TdJamKerjaMesin::find($id);
-        $machine = MsMachine::where('id', $item->machine_id)->first();
+        $item      = TdJamKerjaMesin::find($id);
+        $machine   = MsMachine::where('id', $item->machine_id)->first();
         $msemployee = MsEmployee::where('id', $item->employee_id)->first();
         $jamMatiMesin = TdJamKerjaJamMatiMesin::with('jamMatiMesin')
             ->where('jam_kerja_mesin_id', $id)
             ->get()
             ->map(function ($item) {
                 return [
-                    'id' => $item->id,
+                    'id'                => $item->id,
                     'jam_mati_mesin_id' => $item->jamMatiMesin->id,
-                    'code' => trim($item->jamMatiMesin->code, 'I'),
-                    'name' => $item->jamMatiMesin->name,
-                    'off_hour' => Carbon::parse($item->off_hour)->format('H:i'),
-                    'off_hour_minutes' => formatTime::timeToMinutes($item->off_hour),
-                    'from' => isset($item->from) ? Carbon::parse($item->from)->format('H:i') : null,
-                    'to' => isset($item->to) ? Carbon::parse($item->to)->format('H:i') : null,
+                    'code'              => trim($item->jamMatiMesin->code, 'I'),
+                    'name'              => $item->jamMatiMesin->name,
+                    'off_hour'          => Carbon::parse($item->off_hour)->format('H:i'),
+                    'off_hour_minutes'  => formatTime::timeToMinutes($item->off_hour),
+                    'from'              => isset($item->from) ? Carbon::parse($item->from)->format('H:i') : null,
+                    'to'                => isset($item->to)   ? Carbon::parse($item->to)->format('H:i')   : null,
                 ];
             });
 
-        $this->orderid = $item->id;
+        $this->orderid      = $item->id;
         $this->working_date = $item->working_date;
-        $this->work_shift = $item->work_shift;
-        $this->machineno = $machine->machineno;
-        $this->machinename = $machine->machinename;
-        $this->employeeno = $msemployee->employeeno ?? '';
-        $this->empname = $msemployee->empname ?? '';
-        $this->work_hour = Carbon::parse($item->work_hour)->format('H:i');
-        $this->totalOnHour = Carbon::parse($item->on_hour)->format('H:i');
+        $this->work_shift   = $item->work_shift;
+        $this->machineno    = $machine->machineno;
+        $this->machinename  = $machine->machinename;
+        $this->employeeno   = $msemployee->employeeno ?? '';
+        $this->empname      = $msemployee->empname ?? '';
+        $this->work_hour    = Carbon::parse($item->work_hour)->format('H:i');
+        $this->totalOnHour  = Carbon::parse($item->on_hour)->format('H:i');
         $this->totalOffHour = formatTime::minutesToTime($jamMatiMesin->sum('off_hour_minutes'));
-
         $this->dataJamMatiMesin = $jamMatiMesin->toArray();
 
         $this->dispatch('showModalUpdate');
     }
 
-    public function closeModal()
+    public function closeModal(): void
     {
         $this->jamMatiDataUpdated = false;
     }
 
-    public function resetInput()
+    public function resetInput(): void
     {
         $this->working_date = '';
-        $this->work_shift = '';
-        $this->machineno = '';
-        $this->machinename = '';
-        $this->employeeno = '';
-        $this->empname = '';
-        $this->work_hour = '08:00';
+        $this->work_shift   = '';
+        $this->machineno    = '';
+        $this->machinename  = '';
+        $this->employeeno   = '';
+        $this->empname      = '';
+        $this->work_hour    = '08:00';
         $this->totalOffHour = '00:00';
-        $this->totalOnHour = '08:00';
+        $this->totalOnHour  = '08:00';
     }
 
-    public function resetInputJamMatiMesin()
+    public function resetInputJamMatiMesin(): void
     {
-        $this->jamMatiMesinId = '';
+        $this->jamMatiMesinId   = '';
         $this->jamMatiMesinCode = '';
         $this->jamMatiMesinName = '';
-        $this->off_hour = '00:00';
-        $this->jamMatiFrom = '';
-        $this->jamMatiTo = '';
+        $this->off_hour         = '00:00';
+        $this->jamMatiFrom      = '';
+        $this->jamMatiTo        = '';
     }
 
     protected function computeOffHourFromTimes(): void
@@ -202,103 +201,94 @@ class InfureJamKerjaController extends Component
             $this->off_hour = '00:00';
             return;
         }
-
         try {
             $from = Carbon::createFromFormat('H:i', $this->jamMatiFrom);
-            $to = Carbon::createFromFormat('H:i', $this->jamMatiTo);
-
-            if ($to->lessThan($from)) {
-                $to->addDay();
-            }
-
-            $minutes = $to->diffInMinutes($from);
-            $this->off_hour = formatTime::minutesToTime($minutes);
+            $to   = Carbon::createFromFormat('H:i', $this->jamMatiTo);
+            if ($to->lessThan($from)) { $to->addDay(); }
+            $this->off_hour = formatTime::minutesToTime($to->diffInMinutes($from));
         } catch (\Exception $e) {
             $this->off_hour = '00:00';
         }
     }
 
-    public function updatedJamMatiFrom($value)
+    public function updatedJamMatiFrom($value): void
     {
         $this->jamMatiFrom = $value;
         $this->computeOffHourFromTimes();
         $this->skipRender();
     }
 
-    public function updatedJamMatiTo($value)
+    public function updatedJamMatiTo($value): void
     {
         $this->jamMatiTo = $value;
         $this->computeOffHourFromTimes();
         $this->skipRender();
     }
 
-    public function showModalJamMatiMesin()
+    public function showModalJamMatiMesin(): void
     {
         $this->resetInputJamMatiMesin();
         $this->dispatch('showModalJamMatiMesin');
-        // Mencegah render ulang
         $this->skipRender();
     }
 
-    public function addJamMatiMesin()
+    public function addJamMatiMesin(): void
     {
         try {
-            // compute off_hour from provided times first
             $this->computeOffHourFromTimes();
 
-            $validatedData = $this->validate([
-                'jamMatiMesinId' => 'required',
+            $this->validate([
+                'jamMatiMesinId'   => 'required',
                 'jamMatiMesinCode' => 'required',
                 'jamMatiMesinName' => 'required',
-                'jamMatiFrom' => 'required',
-                'jamMatiTo' => 'required',
-                'off_hour' => 'required',
+                'jamMatiFrom'      => 'required',
+                'jamMatiTo'        => 'required',
+                'off_hour'         => 'required',
             ], [
-                'jamMatiMesinId.required' => 'Jam Mati Mesin harus diisi',
+                'jamMatiMesinId.required'   => 'Jam Mati Mesin harus diisi',
                 'jamMatiMesinCode.required' => 'Jam Mati Mesin harus diisi',
                 'jamMatiMesinName.required' => 'Nama Jam Mati Mesin harus diisi',
-                'jamMatiFrom.required' => 'Field Dari harus diisi',
-                'jamMatiTo.required' => 'Field Sampai harus diisi',
-                'off_hour.required' => 'Lama Mesin Mati harus diisi',
+                'jamMatiFrom.required'      => 'Field Dari harus diisi',
+                'jamMatiTo.required'        => 'Field Sampai harus diisi',
+                'off_hour.required'         => 'Lama Mesin Mati harus diisi',
             ]);
 
-            $workHourMinutes = formatTime::timeToMinutes($this->work_hour);
-            $offHourMinutes = formatTime::timeToMinutes($this->off_hour);
+            $workHourMinutes     = formatTime::timeToMinutes($this->work_hour);
+            $offHourMinutes      = formatTime::timeToMinutes($this->off_hour);
             $totalOffHourMinutes = formatTime::timeToMinutes($this->totalOffHour);
 
-            // Validasi terhadap batas maksimum (8 jam = 480 menit)
             if ($totalOffHourMinutes + $offHourMinutes > 480) {
-                return $this->dispatch('notification', ['type' => 'warning', 'message' => 'Total Lama Mesin Mati melebihi 8 jam']);
+                $this->dispatch('notification', ['type' => 'warning', 'message' => 'Total Lama Mesin Mati melebihi 8 jam']);
+                return;
             }
 
             $newTotalOffMinutes = $totalOffHourMinutes + $offHourMinutes;
             $this->totalOffHour = formatTime::minutesToTime($newTotalOffMinutes);
-            $this->totalOnHour = formatTime::minutesToTime($workHourMinutes - $newTotalOffMinutes);
+            $this->totalOnHour  = formatTime::minutesToTime($workHourMinutes - $newTotalOffMinutes);
 
-            $data = [
-                'id' => count($this->dataJamMatiMesin) + 1,
+            $entry = [
+                'id'                => count($this->dataJamMatiMesin) + 1,
                 'jam_mati_mesin_id' => $this->jamMatiMesinId,
-                'code' => $this->jamMatiMesinCode,
-                'name' => $this->jamMatiMesinName,
-                'off_hour' => $this->off_hour,
-                'from' => $this->jamMatiFrom,
-                'to' => $this->jamMatiTo,
+                'code'              => $this->jamMatiMesinCode,
+                'name'              => $this->jamMatiMesinName,
+                'off_hour'          => $this->off_hour,
+                'from'              => $this->jamMatiFrom,
+                'to'                => $this->jamMatiTo,
             ];
-            $this->dataJamMatiMesin[] = $data;
+            $this->dataJamMatiMesin[] = $entry;
 
-            // jika dilakukan pada update
             if ($this->orderid) {
-                $data =  [
+                TdJamKerjaJamMatiMesin::insert([
                     'jam_kerja_mesin_id' => $this->orderid,
-                    'jam_mati_mesin_id' => $this->jamMatiMesinId,
-                    'off_hour' => $data['off_hour'],
-                    'from' => $this->jamMatiFrom,
-                    'to' => $this->jamMatiTo,
-                ];
-                TdJamKerjaJamMatiMesin::insert($data);
-                TdJamKerjaMesin::where('id', $this->orderid)->update(['off_hour' => $this->totalOffHour, 'on_hour' => $this->totalOnHour]);
-
-                $this->getData();
+                    'jam_mati_mesin_id'  => $this->jamMatiMesinId,
+                    'off_hour'           => $entry['off_hour'],
+                    'from'               => $this->jamMatiFrom,
+                    'to'                 => $this->jamMatiTo,
+                ]);
+                TdJamKerjaMesin::where('id', $this->orderid)->update([
+                    'off_hour' => $this->totalOffHour,
+                    'on_hour'  => $this->totalOnHour,
+                ]);
             }
 
             $this->dispatch('notification', ['type' => 'success', 'message' => 'Order saved successfully.']);
@@ -309,15 +299,16 @@ class InfureJamKerjaController extends Component
         }
     }
 
-    public function deleteJamMatiMesin($orderId)
+    public function deleteJamMatiMesin($orderId): void
     {
         $index = array_search($orderId, array_column($this->dataJamMatiMesin, 'id'));
-
         if ($index !== false) {
-            // mengurangi dari total lama mesin mati
-            $this->totalOffHour = formatTime::minutesToTime(formatTime::timeToMinutes($this->totalOffHour) - formatTime::timeToMinutes($this->dataJamMatiMesin[$index]['off_hour']));
-            $workHourMinutes = formatTime::timeToMinutes($this->work_hour);
-            $this->totalOnHour = formatTime::minutesToTime($workHourMinutes - formatTime::timeToMinutes($this->totalOffHour));
+            $this->totalOffHour = formatTime::minutesToTime(
+                formatTime::timeToMinutes($this->totalOffHour) - formatTime::timeToMinutes($this->dataJamMatiMesin[$index]['off_hour'])
+            );
+            $this->totalOnHour = formatTime::minutesToTime(
+                formatTime::timeToMinutes($this->work_hour) - formatTime::timeToMinutes($this->totalOffHour)
+            );
             array_splice($this->dataJamMatiMesin, $index, 1);
         }
 
@@ -325,17 +316,17 @@ class InfureJamKerjaController extends Component
             $exist = TdJamKerjaJamMatiMesin::where('id', $orderId)->first();
             if ($exist) {
                 TdJamKerjaJamMatiMesin::where('id', $orderId)->delete();
-
-                // update total lama mesin mati
-                TdJamKerjaMesin::where('id', $this->orderid)->update(['off_hour' => $this->totalOffHour, 'on_hour' => $this->totalOnHour]);
-                $this->getData();
+                TdJamKerjaMesin::where('id', $this->orderid)->update([
+                    'off_hour' => $this->totalOffHour,
+                    'on_hour'  => $this->totalOnHour,
+                ]);
             }
         }
 
         $this->dispatch('notification', ['type' => 'success', 'message' => 'Data Berhasil di Hapus']);
     }
 
-    public function validateWorkHour()
+    public function validateWorkHour(): void
     {
         if (isset($this->work_hour) && $this->work_hour > '08:00') {
             $this->work_hour = '08:00';
@@ -343,18 +334,17 @@ class InfureJamKerjaController extends Component
         }
     }
 
-    public function delete($id)
+    public function delete($id): void
     {
         $this->idDelete = $id;
         $this->dispatch('showModalDelete');
         $this->skipRender();
     }
 
-    public function destroy()
+    public function destroy(): void
     {
         try {
             TdJamKerjaMesin::where('id', $this->idDelete)->delete();
-            $this->getData();
             $this->dispatch('closeModalDelete');
             $this->dispatch('notification', ['type' => 'success', 'message' => 'Order deleted successfully.']);
         } catch (\Exception $e) {
@@ -362,106 +352,94 @@ class InfureJamKerjaController extends Component
         }
     }
 
-    public function save()
+    public function save(): void
     {
         try {
-            $validatedData = $this->validate([
+            $this->validate([
                 'working_date' => 'required',
-                'work_shift' => 'required',
-                'machineno' => 'required',
-                'employeeno' => 'required',
-                'work_hour' => 'required',
+                'work_shift'   => 'required',
+                'machineno'    => 'required',
+                'employeeno'   => 'required',
+                'work_hour'    => 'required',
             ], [
                 'working_date.required' => 'Tanggal Produksi harus diisi',
-                'work_shift.required' => 'Shift Kerja harus diisi',
-                'machineno.required' => 'Nomor Mesin harus diisi',
-                'employeeno.required' => 'Petugas harus diisi',
-                'work_hour.required' => 'Jam Kerja harus diisi',
+                'work_shift.required'   => 'Shift Kerja harus diisi',
+                'machineno.required'    => 'Nomor Mesin harus diisi',
+                'employeeno.required'   => 'Petugas harus diisi',
+                'work_hour.required'    => 'Jam Kerja harus diisi',
             ]);
 
-            // menghitung waktu on hour
             $workHour = Carbon::parse($this->work_hour);
-            $offHour = Carbon::parse($this->totalOffHour);
-            $interval = $workHour->diff($offHour);
-            $onHour = $interval->format('%H:%I');
+            $offHour  = Carbon::parse($this->totalOffHour);
+            $onHour   = $workHour->diff($offHour)->format('%H:%I');
 
             DB::beginTransaction();
+
             if (isset($this->orderid)) {
-                $machine = MsMachine::where('machineno', $this->machineno)->first();
+                $machine    = MsMachine::where('machineno', $this->machineno)->first();
                 $msemployee = MsEmployee::where('employeeno', $this->employeeno)->first();
 
                 TdJamKerjaMesin::where('id', $this->orderid)->update([
                     'working_date' => $this->working_date,
-                    'work_shift' => $this->work_shift,
-                    'machine_id' => $machine->id,
+                    'work_shift'   => $this->work_shift,
+                    'machine_id'   => $machine->id,
                     'department_id' => departmentHelper::infureDivision()->id,
-                    'employee_id' => $msemployee->id,
-                    'work_hour' => $this->work_hour,
-                    'off_hour' => $this->totalOffHour,
-                    'on_hour' => $onHour,
-                    'created_on' => Carbon::now(),
-                    'created_by' => auth()->user()->username,
-                    'updated_on' => Carbon::now(),
-                    'updated_by' => auth()->user()->username,
+                    'employee_id'  => $msemployee->id,
+                    'work_hour'    => $this->work_hour,
+                    'off_hour'     => $this->totalOffHour,
+                    'on_hour'      => $onHour,
+                    'created_on'   => Carbon::now(),
+                    'created_by'   => auth()->user()->username,
+                    'updated_on'   => Carbon::now(),
+                    'updated_by'   => auth()->user()->username,
                 ]);
                 $this->reset(['employeeno', 'empname', 'machineno', 'machinename', 'working_date', 'work_shift']);
                 $this->resetInput();
                 $this->dispatch('closeModalUpdate');
             } else {
-                $machine = MsMachine::where('machineno', $this->machineno)->first();
+                $machine    = MsMachine::where('machineno', $this->machineno)->first();
                 $msemployee = MsEmployee::where('employeeno', $this->employeeno)->first();
 
-                // get data jam kerja mesin jika ada
                 $existing = TdJamKerjaMesin::with('jamKerjaJamMatiMesin')
                     ->where('working_date', $this->working_date)
                     ->where('machine_id', $machine->id)
                     ->where('work_shift', $this->work_shift)
                     ->whereDoesntHave('jamKerjaJamMatiMesin', function ($query) {
-                        $query->whereHas('jamMatiMesin', function ($q) {
-                            $q->where('id', 10);
-                        });
+                        $query->whereHas('jamMatiMesin', function ($q) { $q->where('id', 10); });
                     })
                     ->first();
                 if ($existing) {
-                    return $this->dispatch('notification', ['type' => 'warning', 'message' => 'Data sudah ada. Silakan edit data tersebut jika ingin mengubahnya.']);
+                    $this->dispatch('notification', ['type' => 'warning', 'message' => 'Data sudah ada. Silakan edit data tersebut jika ingin mengubahnya.']);
+                    return;
                 }
 
-                // Upsert menggunakan kombinasi unique (working_date, machine_id, work_shift)
                 $now = Carbon::now();
-                $insertRow = [
-                    'working_date'   => $this->working_date,
-                    'work_shift'     => $this->work_shift,
-                    'machine_id'     => $machine->id,
-                    'employee_id'    => $msemployee->id,
-                    'department_id'  => departmentHelper::infureDivision()->id,
-                    'work_hour'      => $this->work_hour,
-                    'off_hour'       => $this->totalOffHour,
-                    'on_hour'        => $onHour,
-                    'created_on'     => $now,
-                    'created_by'     => auth()->user()->username,
-                    'updated_on'     => $now,
-                    'updated_by'     => auth()->user()->username,
-                ];
+                TdJamKerjaMesin::upsert([[
+                    'working_date'  => $this->working_date,
+                    'work_shift'    => $this->work_shift,
+                    'machine_id'    => $machine->id,
+                    'employee_id'   => $msemployee->id,
+                    'department_id' => departmentHelper::infureDivision()->id,
+                    'work_hour'     => $this->work_hour,
+                    'off_hour'      => $this->totalOffHour,
+                    'on_hour'       => $onHour,
+                    'created_on'    => $now,
+                    'created_by'    => auth()->user()->username,
+                    'updated_on'    => $now,
+                    'updated_by'    => auth()->user()->username,
+                ]], ['working_date', 'machine_id', 'work_shift'], [
+                    'employee_id', 'department_id', 'work_hour', 'off_hour', 'on_hour', 'updated_on', 'updated_by',
+                ]);
 
-                // Kolom unik sebagai constraint upsert
-                $uniqueBy = ['working_date', 'machine_id', 'work_shift'];
-
-                // Kolom yang akan diupdate jika record sudah ada
-                $updateCols = ['employee_id', 'department_id', 'work_hour', 'off_hour', 'on_hour', 'updated_on', 'updated_by'];
-
-                TdJamKerjaMesin::upsert([$insertRow], $uniqueBy, $updateCols);
-
-                // Ambil record yang sekarang tersimpan/diupdate
                 $jamKerjaMesin = TdJamKerjaMesin::where('working_date', $this->working_date)
                     ->where('machine_id', $machine->id)
                     ->where('work_shift', $this->work_shift)
                     ->first();
 
-                // Simpan/replace jam mati mesin: hapus dulu yg lama lalu insert yg baru
                 TdJamKerjaJamMatiMesin::where('jam_kerja_mesin_id', $jamKerjaMesin->id)->delete();
 
                 if (!empty($this->dataJamMatiMesin)) {
-                    $dataJamMatiMesin = array_map(function ($item) use ($jamKerjaMesin) {
+                    TdJamKerjaJamMatiMesin::insert(array_map(function ($item) use ($jamKerjaMesin) {
                         return [
                             'jam_kerja_mesin_id' => $jamKerjaMesin->id,
                             'jam_mati_mesin_id'  => $item['jam_mati_mesin_id'],
@@ -469,206 +447,188 @@ class InfureJamKerjaController extends Component
                             'from'               => $item['from'] ?? null,
                             'to'                 => $item['to'] ?? null,
                         ];
-                    }, $this->dataJamMatiMesin);
-
-                    TdJamKerjaJamMatiMesin::insert($dataJamMatiMesin);
+                    }, $this->dataJamMatiMesin));
                 }
 
-                // Pastikan orderid diarahkan ke record yang tersimpan/diupdate
                 $this->orderid = $jamKerjaMesin->id;
                 $this->resetInputJamMatiMesin();
                 $this->dataJamMatiMesin = [];
-
                 $this->reset(['employeeno', 'empname', 'machineno', 'machinename', 'working_date', 'work_shift']);
                 $this->resetInput();
                 $this->dispatch('closeModalCreate');
             }
-            $this->getData();
+
             $this->jamMatiDataUpdated = false;
-
-
             DB::commit();
             $this->dispatch('notification', ['type' => 'success', 'message' => 'Work hour saved successfully.']);
+        } catch (\Illuminate\Validation\ValidationException $e) {
+            $this->dispatch('notification', ['type' => 'warning', 'message' => $e->validator->errors()]);
         } catch (\Exception $e) {
             DB::rollBack();
             $this->dispatch('notification', ['type' => 'error', 'message' => 'Failed to save the order: ' . $e->getMessage()]);
-        } catch (\Illuminate\Validation\ValidationException $e) {
-            $this->dispatch('notification', ['type' => 'warning', 'message' => $e->validator->errors()]);
         }
     }
 
-    public function updatedJamMatiMesinCode($value)
+    public function updatedJamMatiMesinCode($value): void
     {
-        // Normalize
         $code = trim((string) $value);
         $this->jamMatiMesinCode = $code;
 
-        // Guard: kosong
-        if ($code === '') {
-            return $this->notify('warning', 'Jam Mati Mesin Tidak Boleh Kosong');
-        }
+        if ($code === '') { $this->notify('warning', 'Jam Mati Mesin Tidak Boleh Kosong'); return; }
+        if (Str::length($code) < 3) { $this->notify('warning', 'Jam Mati Mesin Minimal 3 Karakter'); return; }
 
-        // Guard: minimal 3 char
-        if (Str::length($code) < 3) {
-            return $this->notify('warning', 'Jam Mati Mesin Minimal 3 Karakter');
-        }
-
-        // Pastikan prefix "I" hanya sekali
         $fullCode = Str::startsWith($code, 'I') ? $code : 'I' . $code;
-
-        // Query hemat kolom
-        $jam = MsJamMatiMesin::query()
-            ->select('id', 'name')
-            ->where('code', $fullCode)
-            ->first();
+        $jam = MsJamMatiMesin::select('id', 'name')->where('code', $fullCode)->first();
 
         if (!$jam) {
-            $this->jamMatiMesinId = '';
-            $this->jamMatiMesinName = '';
-            $this->jamMatiMesinCode = '';
-
-            return $this->notify('warning', "Jam Mati Mesin {$code} Tidak Terdaftar");
+            $this->jamMatiMesinId = $this->jamMatiMesinName = $this->jamMatiMesinCode = '';
+            $this->notify('warning', "Jam Mati Mesin {$code} Tidak Terdaftar");
+            return;
         }
 
-        // OK
         $this->jamMatiMesinId   = $jam->id;
         $this->jamMatiMesinName = $jam->name;
     }
 
-    public function updatedMachineno($machineno)
+    public function updatedMachineno($machineno): void
     {
         $this->machineno = $machineno;
+        if (empty($machineno)) return;
 
-        if (isset($this->machineno) && $this->machineno != '') {
-            $machine = MsMachine::where('machineno', 'ilike', '%' . $this->machineno)
-                ->whereIn('department_id', departmentHelper::infureDepartment())
-                ->orderBy('machineno', 'ASC')
-                ->first();
-            if ($machine == null) {
-                $this->dispatch('notification', ['type' => 'warning', 'message' => 'Machine ' . $this->machineno . ' Tidak Terdaftar']);
-                $this->machinename = '';
-                $this->machineno = '';
-            } else {
-                $this->machineno = $machine->machineno;
-                $this->machinename = $machine->machinename;
-            }
+        $machine = MsMachine::where('machineno', 'ilike', '%' . $machineno)
+            ->whereIn('department_id', departmentHelper::infureDepartment())
+            ->orderBy('machineno', 'ASC')
+            ->first();
+
+        if (!$machine) {
+            $this->dispatch('notification', ['type' => 'warning', 'message' => 'Machine ' . $machineno . ' Tidak Terdaftar']);
+            $this->machinename = $this->machineno = '';
+        } else {
+            $this->machineno   = $machine->machineno;
+            $this->machinename = $machine->machinename;
         }
     }
 
-    public function updatedEmployeeno($employeeno)
+    public function updatedEmployeeno($employeeno): void
     {
         $this->employeeno = $employeeno;
+        if (empty($employeeno) || strlen($employeeno) < 3) return;
 
-        if (isset($this->employeeno) && $this->employeeno != '' && strlen($this->employeeno) >= 3) {
-            $msemployee = MsEmployee::where('employeeno', 'ilike', '%' . $this->employeeno)->active()->first();
-
-            if ($msemployee == null) {
-                $this->empname = '';
-                $this->dispatch('notification', ['type' => 'warning', 'message' => 'Employee ' . $this->employeeno . ' Tidak Terdaftar']);
-            } else {
-                $this->employeeno = $msemployee->employeeno;
-                $this->empname = $msemployee->empname;
-            }
+        $msemployee = MsEmployee::where('employeeno', 'ilike', '%' . $employeeno)->active()->first();
+        if (!$msemployee) {
+            $this->empname = '';
+            $this->dispatch('notification', ['type' => 'warning', 'message' => 'Employee ' . $employeeno . ' Tidak Terdaftar']);
+        } else {
+            $this->employeeno = $msemployee->employeeno;
+            $this->empname    = $msemployee->empname;
         }
-    }
-
-    public function getData()
-    {
-        $data = DB::table('tdjamkerjamesin AS tdjkm')
-            ->select(
-                'tdjkm.id',
-                'tdjkm.working_date',
-                'tdjkm.work_shift',
-                'tdjkm.work_hour',
-                'tdjkm.off_hour',
-                'tdjkm.on_hour',
-                'tdjkm.updated_by',
-                'tdjkm.updated_on',
-                'tdjkm.created_on',
-                'msm.machineno',
-                'mse.empname',
-                'mse.employeeno',
-            )
-            ->leftJoin('msmachine AS msm', 'msm.id', '=', 'tdjkm.machine_id')
-            ->leftJoin('msemployee AS mse', 'mse.id', '=', 'tdjkm.employee_id')
-            ->whereIn('tdjkm.department_id', departmentHelper::infureDivision());
-
-        if ($this->transaksi == 1) {
-            if (isset($this->tglMasuk) && $this->tglMasuk != "" && $this->tglMasuk != "undefined") {
-                $data = $data->where('tdjkm.working_date', '>=', $this->tglMasuk);
-            }
-
-            if (isset($this->tglKeluar) && $this->tglKeluar != "" && $this->tglKeluar != "undefined") {
-                $data = $data->where('tdjkm.working_date', '<=', $this->tglKeluar);
-            }
-        } else if ($this->transaksi == 2) {
-            if (isset($this->tglMasuk) && $this->tglMasuk != "" && $this->tglMasuk != "undefined") {
-                $data = $data->where('tdjkm.created_on', '>=', $this->tglMasuk . " 00:00:00");
-            }
-
-            if (isset($this->tglKeluar) && $this->tglKeluar != "" && $this->tglKeluar != "undefined") {
-                $data = $data->where('tdjkm.created_on', '<=', $this->tglKeluar . " 23:59:59");
-            }
-        }
-
-        if (isset($this->machine_id) && $this->machine_id['value'] != "" && $this->machine_id != "undefined") {
-            $data = $data->where('tdjkm.machine_id', $this->machine_id['value']);
-        }
-        if (isset($this->work_shift_filter) && $this->work_shift_filter['value'] != "" && $this->work_shift_filter != "undefined") {
-            $data = $data->where('tdjkm.work_shift', $this->work_shift_filter);
-        }
-        if (isset($this->searchTerm) && $this->searchTerm != '') {
-            $data = $data->where(function ($query) {
-                $query->where('msm.machineno', 'ilike', '%' . $this->searchTerm . '%')
-                    ->orWhere('msm.machinename', 'ilike', '%' . $this->searchTerm . '%');
-            });
-        }
-        $this->data = $data->orderBy('tdjkm.updated_on', 'DESC')->get();
     }
 
     public function export()
     {
         $this->startHeavyJob();
-        // validasi
         if ($this->tglMasuk == $this->tglKeluar) {
             $this->dispatch('notification', ['type' => 'warning', 'message' => 'Tanggal Masuk dan Tanggal Keluar tidak boleh sama']);
             return;
-        } else if (Carbon::parse($this->tglMasuk) > Carbon::parse($this->tglKeluar)) {
+        }
+        if (Carbon::parse($this->tglMasuk) > Carbon::parse($this->tglKeluar)) {
             $this->dispatch('notification', ['type' => 'warning', 'message' => 'Tanggal Masuk tidak boleh lebih besar dari Tanggal Keluar']);
             return;
         }
 
-        $tglMasuk = Carbon::parse($this->tglMasuk . " 07:01:00");
-        $tglKeluar = Carbon::parse($this->tglKeluar . " 07:00:00");
         $filter = [
-            'machine_id' => $this->machine_id['value'] ?? null,
-            'work_shift' => $this->work_shift_filter['value'] ?? null,
+            'machine_id' => $this->machine_id ?? null,
+            'work_shift' => $this->work_shift_filter ?? null,
             'searchTerm' => $this->searchTerm ?? null,
-            'transaksi' => $this->transaksi ?? 1,
+            'transaksi'  => $this->transaksi ?? 1,
         ];
 
         $checklist = new CheckListJamKerjaController();
-        $response = $checklist->checklistJamKerja($tglMasuk, $tglKeluar, $filter, 'INFURE');
-        if ($response['status'] == 'success') {
+        $response  = $checklist->checklistJamKerja(
+            Carbon::parse($this->tglMasuk . ' 07:01:00'),
+            Carbon::parse($this->tglKeluar . ' 07:00:00'),
+            $filter,
+            'INFURE'
+        );
+        if ($response['status'] === 'success') {
             return response()->download($response['filename']);
-        } else if ($response['status'] == 'error') {
-            $this->dispatch('notification', ['type' => 'warning', 'message' => $response['message']]);
-            return;
         }
+        $this->dispatch('notification', ['type' => 'warning', 'message' => $response['message']]);
     }
 
     public function render()
     {
-        return view('livewire.jam-kerja.infure', [
-            'data' => $this->data
-        ])->extends('layouts.master');
-    }
+        $machine = Cache::remember('ms_machines_infure_jk', 3600, fn() =>
+            MsMachine::whereIn('department_id', departmentHelper::infurePabrikDepartment()->pluck('id'))
+                ->select(['id', 'machineno', 'machinename'])
+                ->get()
+        );
+        $workShift = Cache::remember('ms_workshifts_jk', 3600, fn() =>
+            MsWorkingShift::active()->select(['id', 'work_shift'])->get()
+        );
 
-    public function rendered()
-    {
-        if (!$this->isUpdatingSorting && !$this->jamMatiDataUpdated) {
-            $this->dispatch('initDataTable');
+        if (!$this->isLoaded) {
+            return view('livewire.jam-kerja.infure', [
+                'data'      => new \Illuminate\Pagination\LengthAwarePaginator([], 0, $this->perPage),
+                'machine'   => $machine,
+                'workShift' => $workShift,
+            ])->extends('layouts.master');
         }
+
+        try {
+            $data = DB::table('tdjamkerjamesin AS tdjkm')
+                ->select([
+                    'tdjkm.id',
+                    'tdjkm.working_date',
+                    'tdjkm.work_shift',
+                    'tdjkm.work_hour',
+                    'tdjkm.off_hour',
+                    'tdjkm.on_hour',
+                    'tdjkm.updated_by',
+                    'tdjkm.updated_on',
+                    'tdjkm.created_on',
+                    'msm.machineno',
+                    'mse.empname',
+                    'mse.employeeno',
+                ])
+                ->leftJoin('msmachine AS msm', 'msm.id', '=', 'tdjkm.machine_id')
+                ->leftJoin('msemployee AS mse', 'mse.id', '=', 'tdjkm.employee_id')
+                ->whereIn('tdjkm.department_id', departmentHelper::infureDivision());
+
+            $dateColumn = $this->transaksi == 2 ? 'tdjkm.created_on' : 'tdjkm.working_date';
+            if (!empty($this->tglMasuk) && $this->tglMasuk !== 'undefined') {
+                $suffix = $this->transaksi == 2 ? ' 00:00:00' : '';
+                $data->where($dateColumn, '>=', $this->tglMasuk . $suffix);
+            }
+            if (!empty($this->tglKeluar) && $this->tglKeluar !== 'undefined') {
+                $suffix = $this->transaksi == 2 ? ' 23:59:59' : '';
+                $data->where($dateColumn, '<=', $this->tglKeluar . $suffix);
+            }
+            if (!empty($this->machine_id) && $this->machine_id !== 'undefined') {
+                $data->where('tdjkm.machine_id', $this->machine_id);
+            }
+            if (!empty($this->work_shift_filter) && $this->work_shift_filter !== 'undefined') {
+                $data->where('tdjkm.work_shift', $this->work_shift_filter);
+            }
+            if (!empty($this->searchTerm) && $this->searchTerm !== 'undefined') {
+                $data->where(function ($q) {
+                    $q->where('msm.machineno', 'ilike', '%' . $this->searchTerm . '%')
+                      ->orWhere('msm.machinename', 'ilike', '%' . $this->searchTerm . '%');
+                });
+            }
+
+            $data = $data->orderBy($this->sortColumn, $this->sortDirection)
+                         ->paginate($this->perPage);
+        } catch (\Exception $e) {
+            $data = new \Illuminate\Pagination\LengthAwarePaginator([], 0, $this->perPage);
+            $this->dispatch('notification', ['type' => 'error', 'message' => 'Terjadi kesalahan: ' . $e->getMessage()]);
+        }
+
+        return view('livewire.jam-kerja.infure', [
+            'data'      => $data,
+            'machine'   => $machine,
+            'workShift' => $workShift,
+        ])->extends('layouts.master');
     }
 
     protected function notify(string $type, string $message): void

--- a/app/Http/Livewire/JamKerja/SeitaiJamKerjaController.php
+++ b/app/Http/Livewire/JamKerja/SeitaiJamKerjaController.php
@@ -14,6 +14,7 @@ use App\Models\TdJamKerjaMesin;
 use Carbon\Carbon;
 use Livewire\Component;
 use App\Traits\HandlesHeavyJob;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Livewire\WithPagination;
 use Livewire\WithoutUrlPagination;
@@ -22,17 +23,25 @@ use Illuminate\Support\Str;
 
 class SeitaiJamKerjaController extends Component
 {
-    use HandlesHeavyJob;
+    use HandlesHeavyJob, WithPagination, WithoutUrlPagination;
+
     protected $paginationTheme = 'bootstrap';
     protected $listeners = ['edit', 'delete'];
-    #[Session]
-    public $tglMasuk;
-    #[Session]
-    public $tglKeluar;
-    public $data = [];
+
+    public bool $isLoaded = false;
+
+    #[Session] public $tglMasuk;
+    #[Session] public $tglKeluar;
+    #[Session] public $transaksi;
+    #[Session] public $work_shift_filter;
+    #[Session] public $machine_id;
+    #[Session] public $searchTerm;
+    #[Session] public $perPage      = 10;
+    #[Session] public $sortColumn   = 'tdjkm.updated_on';
+    #[Session] public $sortDirection = 'desc';
+
     public $machinename;
     public $machineno;
-    public $machine;
     public $msemployee;
     public $employeeno;
     public $jamMatiMesinId;
@@ -42,157 +51,148 @@ class SeitaiJamKerjaController extends Component
     public $jamMatiTo;
     public $off_hour;
     public $dataJamMatiMesin = [];
-    #[Session]
-    public $transaksi;
     public $working_date;
     public $empname;
     public $work_shift;
-    #[Session]
-    public $work_shift_filter;
-    #[Session]
-    public $machine_id;
     public $employee_id;
     public $work_hour = '06:30';
-    public $totalOffHour = "00:00";
-    public $totalOnHour = "08:00";
+    public $totalOffHour = '00:00';
+    public $totalOnHour  = '08:00';
     public $on_hour;
     public $orderid;
-    public $workShift;
-    #[Session]
-    public $searchTerm;
     public $idDelete;
-    #[Session]
-    public $sortingTable;
-    public $isUpdatingSorting = false;
     public $jamMatiDataUpdated = false;
 
-    use WithPagination, WithoutUrlPagination;
+    public function sortBy(string $column): void
+    {
+        $allowed = [
+            'tdjkm.working_date', 'tdjkm.work_shift', 'msm.machineno',
+            'mse.employeeno', 'mse.empname', 'tdjkm.work_hour',
+            'tdjkm.off_hour', 'tdjkm.on_hour', 'tdjkm.updated_on', 'tdjkm.created_on',
+        ];
+        if (!in_array($column, $allowed)) return;
+        if ($this->sortColumn === $column) {
+            $this->sortDirection = $this->sortDirection === 'asc' ? 'desc' : 'asc';
+        } else {
+            $this->sortColumn    = $column;
+            $this->sortDirection = 'asc';
+        }
+        $this->resetPage();
+    }
 
-    public function mount()
+    public function loadData(): void
+    {
+        $this->isLoaded = true;
+    }
+
+    public function mount(): void
     {
         $this->shouldForgetSession();
 
-        if (empty($this->tglMasuk)) {
-            $this->tglMasuk = Carbon::now()->format('d-m-Y');
+        if (is_array($this->machine_id))        { $this->machine_id        = $this->machine_id['value']        ?? null; }
+        if (is_array($this->work_shift_filter)) { $this->work_shift_filter = $this->work_shift_filter['value'] ?? null; }
+
+        if (empty($this->tglMasuk) || !preg_match('/^\d{4}-\d{2}-\d{2}$/', $this->tglMasuk)) {
+            $this->tglMasuk = Carbon::now()->format('Y-m-d');
         }
-        if (empty($this->tglKeluar)) {
-            $this->tglKeluar = Carbon::now()->format('d-m-Y');
+        if (empty($this->tglKeluar) || !preg_match('/^\d{4}-\d{2}-\d{2}$/', $this->tglKeluar)) {
+            $this->tglKeluar = Carbon::now()->format('Y-m-d');
         }
         if (empty($this->transaksi)) {
             $this->transaksi = 1;
         }
-        $this->machine  = MsMachine::whereIn('department_id', departmentHelper::seitaiPabrikDepartment()->pluck('id'))->get();
-        $this->workShift  = MsWorkingShift::active()->get();
-        $this->working_date = Carbon::now()->format('d-m-Y');
-        if (empty($this->sortingTable)) {
-            $this->sortingTable = [[1, 'asc']];
-        }
-        $this->getData();
+
+        $this->working_date = Carbon::now()->format('Y-m-d');
     }
 
-    public function updateSortingTable($value)
+    protected function shouldForgetSession(): void
     {
-        $this->isUpdatingSorting = true;
-        $this->sortingTable = $value;
-
-        // Tidak skip render jika ada update data jam mati
-        if (!$this->jamMatiDataUpdated) {
-            $this->skipRender();
-        }
-
-        $this->isUpdatingSorting = false;
-    }
-
-    protected function shouldForgetSession()
-    {
-        $previousUrl = url()->previous();
-        $previousUrl = last(explode('/', $previousUrl));
-        if (!(Str::contains($previousUrl, 'seitai-jam-kerja'))) {
-            $this->reset('tglMasuk', 'tglKeluar', 'transaksi', 'machine_id', 'work_shift_filter', 'searchTerm', 'sortingTable');
+        $previousUrl = last(explode('/', url()->previous()));
+        if (!Str::contains($previousUrl, 'seitai-jam-kerja')) {
+            $this->reset('tglMasuk', 'tglKeluar', 'transaksi', 'machine_id', 'work_shift_filter', 'searchTerm', 'perPage', 'sortColumn', 'sortDirection');
         }
     }
 
-    public function search()
+    public function search(): void
     {
-        $this->getData();
+        $this->resetPage();
     }
 
-    public function showModalCreate()
+    public function showModalCreate(): void
     {
         if ($this->orderid) {
             $this->dataJamMatiMesin = [];
             $this->orderid = null;
             $this->resetInput();
         }
-        $this->working_date = Carbon::now()->format('d-m-Y');
+        $this->working_date = Carbon::now()->format('Y-m-d');
         $this->dispatch('showModalCreate');
         $this->jamMatiDataUpdated = true;
     }
 
-    public function edit($id)
+    public function edit($id): void
     {
         $this->jamMatiDataUpdated = true;
-        $item = TdJamKerjaMesin::find($id);
-        $machine = MsMachine::where('id', $item->machine_id)->first();
+        $item      = TdJamKerjaMesin::find($id);
+        $machine   = MsMachine::where('id', $item->machine_id)->first();
         $msemployee = MsEmployee::where('id', $item->employee_id)->first();
         $jamMatiMesin = TdJamKerjaJamMatiMesin::with('jamMatiMesin')
             ->where('jam_kerja_mesin_id', $id)
             ->get()
             ->map(function ($item) {
                 return [
-                    'id' => $item->id,
+                    'id'                => $item->id,
                     'jam_mati_mesin_id' => $item->jamMatiMesin->id,
-                    'code' => trim($item->jamMatiMesin->code, 'S'),
-                    'name' => $item->jamMatiMesin->name,
-                    'off_hour' => Carbon::parse($item->off_hour)->format('H:i'),
-                    'off_hour_minutes' => formatTime::timeToMinutes($item->off_hour),
-                    'from' => isset($item->from) ? Carbon::parse($item->from)->format('H:i') : null,
-                    'to' => isset($item->to) ? Carbon::parse($item->to)->format('H:i') : null,
+                    'code'              => trim($item->jamMatiMesin->code, 'S'),
+                    'name'              => $item->jamMatiMesin->name,
+                    'off_hour'          => Carbon::parse($item->off_hour)->format('H:i'),
+                    'off_hour_minutes'  => formatTime::timeToMinutes($item->off_hour),
+                    'from'              => isset($item->from) ? Carbon::parse($item->from)->format('H:i') : null,
+                    'to'                => isset($item->to)   ? Carbon::parse($item->to)->format('H:i')   : null,
                 ];
             });
 
-        $this->orderid = $item->id;
+        $this->orderid      = $item->id;
         $this->working_date = $item->working_date;
-        $this->work_shift = $item->work_shift;
-        $this->machineno = $machine->machineno;
-        $this->machinename = $machine->machinename;
-        $this->employeeno = $msemployee->employeeno ?? '';
-        $this->empname = $msemployee->empname ?? '';
-        $this->work_hour = Carbon::parse($item->work_hour)->format('H:i');
-        $this->totalOnHour = Carbon::parse($item->on_hour)->format('H:i');
+        $this->work_shift   = $item->work_shift;
+        $this->machineno    = $machine->machineno;
+        $this->machinename  = $machine->machinename;
+        $this->employeeno   = $msemployee->employeeno ?? '';
+        $this->empname      = $msemployee->empname ?? '';
+        $this->work_hour    = Carbon::parse($item->work_hour)->format('H:i');
+        $this->totalOnHour  = Carbon::parse($item->on_hour)->format('H:i');
         $this->totalOffHour = formatTime::minutesToTime($jamMatiMesin->sum('off_hour_minutes'));
-
         $this->dataJamMatiMesin = $jamMatiMesin->toArray();
 
         $this->dispatch('showModalUpdate');
     }
 
-    public function closeModal()
+    public function closeModal(): void
     {
         $this->jamMatiDataUpdated = false;
     }
 
-    public function resetInput()
+    public function resetInput(): void
     {
         $this->working_date = '';
-        $this->work_shift = '';
-        $this->machineno = '';
-        $this->machinename = '';
-        $this->employeeno = '';
-        $this->empname = '';
-        $this->work_hour = '06:30';
+        $this->work_shift   = '';
+        $this->machineno    = '';
+        $this->machinename  = '';
+        $this->employeeno   = '';
+        $this->empname      = '';
+        $this->work_hour    = '06:30';
         $this->totalOffHour = '00:00';
-        $this->totalOnHour = '08:00';
+        $this->totalOnHour  = '08:00';
     }
 
-    public function resetInputJamMatiMesin()
+    public function resetInputJamMatiMesin(): void
     {
-        $this->jamMatiMesinId = '';
+        $this->jamMatiMesinId   = '';
         $this->jamMatiMesinCode = '';
         $this->jamMatiMesinName = '';
-        $this->off_hour = '00:00';
-        $this->jamMatiFrom = '';
-        $this->jamMatiTo = '';
+        $this->off_hour         = '00:00';
+        $this->jamMatiFrom      = '';
+        $this->jamMatiTo        = '';
     }
 
     protected function computeOffHourFromTimes(): void
@@ -201,102 +201,94 @@ class SeitaiJamKerjaController extends Component
             $this->off_hour = '00:00';
             return;
         }
-
         try {
             $from = Carbon::createFromFormat('H:i', $this->jamMatiFrom);
-            $to = Carbon::createFromFormat('H:i', $this->jamMatiTo);
-
-            if ($to->lessThan($from)) {
-                $to->addDay();
-            }
-
-            $minutes = $to->diffInMinutes($from);
-            $this->off_hour = formatTime::minutesToTime($minutes);
+            $to   = Carbon::createFromFormat('H:i', $this->jamMatiTo);
+            if ($to->lessThan($from)) { $to->addDay(); }
+            $this->off_hour = formatTime::minutesToTime($to->diffInMinutes($from));
         } catch (\Exception $e) {
             $this->off_hour = '00:00';
         }
     }
 
-    public function updatedJamMatiFrom($value)
+    public function updatedJamMatiFrom($value): void
     {
         $this->jamMatiFrom = $value;
         $this->computeOffHourFromTimes();
         $this->skipRender();
     }
 
-    public function updatedJamMatiTo($value)
+    public function updatedJamMatiTo($value): void
     {
         $this->jamMatiTo = $value;
         $this->computeOffHourFromTimes();
         $this->skipRender();
     }
 
-    public function showModalJamMatiMesin()
+    public function showModalJamMatiMesin(): void
     {
         $this->resetInputJamMatiMesin();
         $this->dispatch('showModalJamMatiMesin');
-        // Mencegah render ulang
         $this->skipRender();
     }
 
-    public function addJamMatiMesin()
+    public function addJamMatiMesin(): void
     {
         try {
             $this->computeOffHourFromTimes();
 
             $this->validate([
-                'jamMatiMesinId' => 'required',
+                'jamMatiMesinId'   => 'required',
                 'jamMatiMesinCode' => 'required',
                 'jamMatiMesinName' => 'required',
-                'jamMatiFrom' => 'required',
-                'jamMatiTo' => 'required',
-                'off_hour' => 'required',
+                'jamMatiFrom'      => 'required',
+                'jamMatiTo'        => 'required',
+                'off_hour'         => 'required',
             ], [
-                'jamMatiMesinId.required' => 'Jam Mati Mesin harus diisi',
+                'jamMatiMesinId.required'   => 'Jam Mati Mesin harus diisi',
                 'jamMatiMesinCode.required' => 'Jam Mati Mesin harus diisi',
                 'jamMatiMesinName.required' => 'Nama Jam Mati Mesin harus diisi',
-                'jamMatiFrom.required' => 'Field Dari harus diisi',
-                'jamMatiTo.required' => 'Field Sampai harus diisi',
-                'off_hour.required' => 'Lama Mesin Mati harus diisi',
+                'jamMatiFrom.required'      => 'Field Dari harus diisi',
+                'jamMatiTo.required'        => 'Field Sampai harus diisi',
+                'off_hour.required'         => 'Lama Mesin Mati harus diisi',
             ]);
 
-            $workHourMinutes = formatTime::timeToMinutes($this->work_hour);
-            $offHourMinutes = formatTime::timeToMinutes($this->off_hour);
+            $workHourMinutes     = formatTime::timeToMinutes($this->work_hour);
+            $offHourMinutes      = formatTime::timeToMinutes($this->off_hour);
             $totalOffHourMinutes = formatTime::timeToMinutes($this->totalOffHour);
 
-            // Validasi terhadap batas maksimum (8 jam = 480 menit)
             if ($totalOffHourMinutes + $offHourMinutes > 480) {
-                return $this->dispatch('notification', ['type' => 'warning', 'message' => 'Total Lama Mesin Mati melebihi 8 jam']);
+                $this->dispatch('notification', ['type' => 'warning', 'message' => 'Total Lama Mesin Mati melebihi 8 jam']);
+                return;
             }
 
             $newTotalOffMinutes = $totalOffHourMinutes + $offHourMinutes;
             $this->totalOffHour = formatTime::minutesToTime($newTotalOffMinutes);
-            $this->totalOnHour = formatTime::minutesToTime($workHourMinutes - $newTotalOffMinutes);
+            $this->totalOnHour  = formatTime::minutesToTime($workHourMinutes - $newTotalOffMinutes);
 
-            $data = [
-                'id' => count($this->dataJamMatiMesin) + 1,
+            $entry = [
+                'id'                => count($this->dataJamMatiMesin) + 1,
                 'jam_mati_mesin_id' => $this->jamMatiMesinId,
-                'code' => $this->jamMatiMesinCode,
-                'name' => $this->jamMatiMesinName,
-                'off_hour' => $this->off_hour,
-                'from' => $this->jamMatiFrom,
-                'to' => $this->jamMatiTo,
+                'code'              => $this->jamMatiMesinCode,
+                'name'              => $this->jamMatiMesinName,
+                'off_hour'          => $this->off_hour,
+                'from'              => $this->jamMatiFrom,
+                'to'                => $this->jamMatiTo,
             ];
-            $this->dataJamMatiMesin[] = $data;
+            $this->dataJamMatiMesin[] = $entry;
 
-            // jika dilakukan pada update
             if ($this->orderid) {
-                $data =  [
+                TdJamKerjaJamMatiMesin::insert([
                     'jam_kerja_mesin_id' => $this->orderid,
-                    'jam_mati_mesin_id' => $this->jamMatiMesinId,
-                    'off_hour' => $data['off_hour'],
-                    'from' => $this->jamMatiFrom,
-                    'to' => $this->jamMatiTo,
-                ];
-                TdJamKerjaJamMatiMesin::insert($data);
-                TdJamKerjaMesin::where('id', $this->orderid)->update(['off_hour' => $this->totalOffHour, 'on_hour' => $this->totalOnHour]);
-
-                $this->getData();
+                    'jam_mati_mesin_id'  => $this->jamMatiMesinId,
+                    'off_hour'           => $entry['off_hour'],
+                    'from'               => $this->jamMatiFrom,
+                    'to'                 => $this->jamMatiTo,
+                ]);
+                TdJamKerjaMesin::where('id', $this->orderid)->update([
+                    'off_hour' => $this->totalOffHour,
+                    'on_hour'  => $this->totalOnHour,
+                ]);
             }
 
             $this->dispatch('notification', ['type' => 'success', 'message' => 'Order saved successfully.']);
@@ -307,15 +299,16 @@ class SeitaiJamKerjaController extends Component
         }
     }
 
-    public function deleteJamMatiMesin($orderId)
+    public function deleteJamMatiMesin($orderId): void
     {
         $index = array_search($orderId, array_column($this->dataJamMatiMesin, 'id'));
-
         if ($index !== false) {
-            // mengurangi dari total lama mesin mati
-            $this->totalOffHour = formatTime::minutesToTime(formatTime::timeToMinutes($this->totalOffHour) - formatTime::timeToMinutes($this->dataJamMatiMesin[$index]['off_hour']));
-            $workHourMinutes = formatTime::timeToMinutes($this->work_hour);
-            $this->totalOnHour = formatTime::minutesToTime($workHourMinutes - formatTime::timeToMinutes($this->totalOffHour));
+            $this->totalOffHour = formatTime::minutesToTime(
+                formatTime::timeToMinutes($this->totalOffHour) - formatTime::timeToMinutes($this->dataJamMatiMesin[$index]['off_hour'])
+            );
+            $this->totalOnHour = formatTime::minutesToTime(
+                formatTime::timeToMinutes($this->work_hour) - formatTime::timeToMinutes($this->totalOffHour)
+            );
             array_splice($this->dataJamMatiMesin, $index, 1);
         }
 
@@ -323,17 +316,17 @@ class SeitaiJamKerjaController extends Component
             $exist = TdJamKerjaJamMatiMesin::where('id', $orderId)->first();
             if ($exist) {
                 TdJamKerjaJamMatiMesin::where('id', $orderId)->delete();
-
-                // update total lama mesin mati
-                TdJamKerjaMesin::where('id', $this->orderid)->update(['off_hour' => $this->totalOffHour, 'on_hour' => $this->totalOnHour]);
-                $this->getData();
+                TdJamKerjaMesin::where('id', $this->orderid)->update([
+                    'off_hour' => $this->totalOffHour,
+                    'on_hour'  => $this->totalOnHour,
+                ]);
             }
         }
 
         $this->dispatch('notification', ['type' => 'success', 'message' => 'Data Berhasil di Hapus']);
     }
 
-    public function validateWorkHour()
+    public function validateWorkHour(): void
     {
         if (isset($this->work_hour) && $this->work_hour > '08:00') {
             $this->work_hour = '08:00';
@@ -341,18 +334,17 @@ class SeitaiJamKerjaController extends Component
         }
     }
 
-    public function delete($id)
+    public function delete($id): void
     {
         $this->idDelete = $id;
         $this->dispatch('showModalDelete');
         $this->skipRender();
     }
 
-    public function destroy()
+    public function destroy(): void
     {
         try {
             TdJamKerjaMesin::where('id', $this->idDelete)->delete();
-            $this->getData();
             $this->dispatch('closeModalDelete');
             $this->dispatch('notification', ['type' => 'success', 'message' => 'Order deleted successfully.']);
         } catch (\Exception $e) {
@@ -360,105 +352,94 @@ class SeitaiJamKerjaController extends Component
         }
     }
 
-    public function save()
+    public function save(): void
     {
         try {
-            $validatedData = $this->validate([
+            $this->validate([
                 'working_date' => 'required',
-                'work_shift' => 'required',
-                'machineno' => 'required',
-                'employeeno' => 'required',
-                'work_hour' => 'required',
+                'work_shift'   => 'required',
+                'machineno'    => 'required',
+                'employeeno'   => 'required',
+                'work_hour'    => 'required',
             ], [
                 'working_date.required' => 'Tanggal Produksi harus diisi',
-                'work_shift.required' => 'Shift Kerja harus diisi',
-                'machineno.required' => 'Nomor Mesin harus diisi',
-                'employeeno.required' => 'Petugas harus diisi',
-                'work_hour.required' => 'Jam Kerja harus diisi',
+                'work_shift.required'   => 'Shift Kerja harus diisi',
+                'machineno.required'    => 'Nomor Mesin harus diisi',
+                'employeeno.required'   => 'Petugas harus diisi',
+                'work_hour.required'    => 'Jam Kerja harus diisi',
             ]);
 
-            // menghitung waktu on hour
             $workHour = Carbon::parse($this->work_hour);
-            $offHour = Carbon::parse($this->totalOffHour);
-            $interval = $workHour->diff($offHour);
-            $onHour = $interval->format('%H:%I');
+            $offHour  = Carbon::parse($this->totalOffHour);
+            $onHour   = $workHour->diff($offHour)->format('%H:%I');
 
             DB::beginTransaction();
+
             if (isset($this->orderid)) {
-                $machine = MsMachine::where('machineno', $this->machineno)->first();
+                $machine    = MsMachine::where('machineno', $this->machineno)->first();
                 $msemployee = MsEmployee::where('employeeno', $this->employeeno)->first();
 
                 TdJamKerjaMesin::where('id', $this->orderid)->update([
-                    'working_date' => $this->working_date,
-                    'work_shift' => $this->work_shift,
-                    'machine_id' => $machine->id,
+                    'working_date'  => $this->working_date,
+                    'work_shift'    => $this->work_shift,
+                    'machine_id'    => $machine->id,
                     'department_id' => departmentHelper::seitaiDivision()->id,
-                    'employee_id' => $msemployee->id,
-                    'work_hour' => $this->work_hour,
-                    'off_hour' => $this->totalOffHour,
-                    'on_hour' => $onHour,
-                    'created_on' => Carbon::now(),
-                    'created_by' => auth()->user()->username,
-                    'updated_on' => Carbon::now(),
-                    'updated_by' => auth()->user()->username,
+                    'employee_id'   => $msemployee->id,
+                    'work_hour'     => $this->work_hour,
+                    'off_hour'      => $this->totalOffHour,
+                    'on_hour'       => $onHour,
+                    'created_on'    => Carbon::now(),
+                    'created_by'    => auth()->user()->username,
+                    'updated_on'    => Carbon::now(),
+                    'updated_by'    => auth()->user()->username,
                 ]);
                 $this->reset(['employeeno', 'empname', 'machineno', 'machinename', 'working_date', 'work_shift']);
                 $this->resetInput();
                 $this->dispatch('closeModalUpdate');
             } else {
-                $machine = MsMachine::where('machineno', $this->machineno)->first();
+                $machine    = MsMachine::where('machineno', $this->machineno)->first();
                 $msemployee = MsEmployee::where('employeeno', $this->employeeno)->first();
-                // cek apakah sudah ada record unik berdasarkan working_date, work_shift, machine_id
+
                 $existing = TdJamKerjaMesin::with('jamKerjaJamMatiMesin')
                     ->where('working_date', $this->working_date)
                     ->where('machine_id', $machine->id)
                     ->where('work_shift', $this->work_shift)
                     ->whereDoesntHave('jamKerjaJamMatiMesin', function ($query) {
-                        $query->whereHas('jamMatiMesin', function ($q) {
-                            $q->where('id', 17);
-                        });
+                        $query->whereHas('jamMatiMesin', function ($q) { $q->where('id', 17); });
                     })
                     ->first();
                 if ($existing) {
-                    return $this->dispatch('notification', ['type' => 'warning', 'message' => 'Data sudah ada. Silakan edit data tersebut jika ingin mengubahnya.']);
+                    $this->dispatch('notification', ['type' => 'warning', 'message' => 'Data sudah ada. Silakan edit data tersebut jika ingin mengubahnya.']);
+                    return;
                 }
 
-                // Upsert menggunakan kombinasi unique (working_date, machine_id, work_shift)
                 $now = Carbon::now();
-                $insertRow = [
-                    'working_date'   => $this->working_date,
-                    'work_shift'     => $this->work_shift,
-                    'machine_id'     => $machine->id,
-                    'employee_id'    => $msemployee->id,
-                    'department_id'  => departmentHelper::seitaiDivision()->id,
-                    'work_hour'      => $this->work_hour,
-                    'off_hour'       => $this->totalOffHour,
-                    'on_hour'        => $onHour,
-                    'created_on'     => $now,
-                    'created_by'     => auth()->user()->username,
-                    'updated_on'     => $now,
-                    'updated_by'     => auth()->user()->username,
-                ];
+                TdJamKerjaMesin::upsert([[
+                    'working_date'  => $this->working_date,
+                    'work_shift'    => $this->work_shift,
+                    'machine_id'    => $machine->id,
+                    'employee_id'   => $msemployee->id,
+                    'department_id' => departmentHelper::seitaiDivision()->id,
+                    'work_hour'     => $this->work_hour,
+                    'off_hour'      => $this->totalOffHour,
+                    'on_hour'       => $onHour,
+                    'created_on'    => $now,
+                    'created_by'    => auth()->user()->username,
+                    'updated_on'    => $now,
+                    'updated_by'    => auth()->user()->username,
+                ]], ['working_date', 'machine_id', 'work_shift'], [
+                    'employee_id', 'department_id', 'work_hour', 'off_hour', 'on_hour', 'updated_on', 'updated_by',
+                ]);
 
-                // Kolom unik sebagai constraint upsert
-                $uniqueBy = ['working_date', 'machine_id', 'work_shift'];
-
-                // Kolom yang akan diupdate jika record sudah ada
-                $updateCols = ['employee_id', 'department_id', 'work_hour', 'off_hour', 'on_hour', 'updated_on', 'updated_by'];
-
-                TdJamKerjaMesin::upsert([$insertRow], $uniqueBy, $updateCols);
-
-                // Ambil record yang sekarang tersimpan/diupdate
                 $jamKerjaMesin = TdJamKerjaMesin::where('working_date', $this->working_date)
                     ->where('machine_id', $machine->id)
                     ->where('work_shift', $this->work_shift)
                     ->first();
 
-                // Simpan/replace jam mati mesin: hapus dulu yg lama lalu insert yg baru
                 TdJamKerjaJamMatiMesin::where('jam_kerja_mesin_id', $jamKerjaMesin->id)->delete();
 
                 if (!empty($this->dataJamMatiMesin)) {
-                    $dataJamMatiMesin = array_map(function ($item) use ($jamKerjaMesin) {
+                    TdJamKerjaJamMatiMesin::insert(array_map(function ($item) use ($jamKerjaMesin) {
                         return [
                             'jam_kerja_mesin_id' => $jamKerjaMesin->id,
                             'jam_mati_mesin_id'  => $item['jam_mati_mesin_id'],
@@ -466,207 +447,188 @@ class SeitaiJamKerjaController extends Component
                             'from'               => $item['from'] ?? null,
                             'to'                 => $item['to'] ?? null,
                         ];
-                    }, $this->dataJamMatiMesin);
-
-                    TdJamKerjaJamMatiMesin::insert($dataJamMatiMesin);
+                    }, $this->dataJamMatiMesin));
                 }
 
-                // Pastikan orderid diarahkan ke record yang tersimpan/diupdate
                 $this->orderid = $jamKerjaMesin->id;
                 $this->resetInputJamMatiMesin();
                 $this->dataJamMatiMesin = [];
-
                 $this->reset(['employeeno', 'empname', 'machineno', 'machinename', 'working_date', 'work_shift']);
                 $this->resetInput();
                 $this->dispatch('closeModalCreate');
             }
-            $this->getData();
+
             $this->jamMatiDataUpdated = false;
-
-
             DB::commit();
             $this->dispatch('notification', ['type' => 'success', 'message' => 'Work hour saved successfully.']);
+        } catch (\Illuminate\Validation\ValidationException $e) {
+            $this->dispatch('notification', ['type' => 'warning', 'message' => $e->validator->errors()]);
         } catch (\Exception $e) {
             DB::rollBack();
             $this->dispatch('notification', ['type' => 'error', 'message' => 'Failed to save the order: ' . $e->getMessage()]);
-        } catch (\Illuminate\Validation\ValidationException $e) {
-            $this->dispatch('notification', ['type' => 'warning', 'message' => $e->validator->errors()]);
         }
     }
 
-
-    public function updatedJamMatiMesinCode($value)
+    public function updatedJamMatiMesinCode($value): void
     {
-        // Normalize
         $code = trim((string) $value);
         $this->jamMatiMesinCode = $code;
 
-        // Guard: kosong
-        if ($code === '') {
-            return $this->notify('warning', 'Jam Mati Mesin Tidak Boleh Kosong');
-        }
+        if ($code === '') { $this->notify('warning', 'Jam Mati Mesin Tidak Boleh Kosong'); return; }
+        if (Str::length($code) < 3) { $this->notify('warning', 'Jam Mati Mesin Minimal 3 Karakter'); return; }
 
-        // Guard: minimal 3 char
-        if (Str::length($code) < 3) {
-            return $this->notify('warning', 'Jam Mati Mesin Minimal 3 Karakter');
-        }
-
-        // Pastikan prefix "S" hanya sekali
         $fullCode = Str::startsWith($code, 'S') ? $code : 'S' . $code;
-
-        // Query hemat kolom
-        $jam = MsJamMatiMesin::query()
-            ->select('id', 'name')
-            ->where('code', $fullCode)
-            ->first();
+        $jam = MsJamMatiMesin::select('id', 'name')->where('code', $fullCode)->first();
 
         if (!$jam) {
-            $this->jamMatiMesinId = '';
-            $this->jamMatiMesinName = '';
-            $this->jamMatiMesinCode = '';
-
-            return $this->notify('warning', "Jam Mati Mesin {$code} Tidak Terdaftar");
+            $this->jamMatiMesinId = $this->jamMatiMesinName = $this->jamMatiMesinCode = '';
+            $this->notify('warning', "Jam Mati Mesin {$code} Tidak Terdaftar");
+            return;
         }
 
-        // OK
         $this->jamMatiMesinId   = $jam->id;
         $this->jamMatiMesinName = $jam->name;
     }
 
-    public function updatedMachineno($machineno)
+    public function updatedMachineno($machineno): void
     {
         $this->machineno = $machineno;
+        if (empty($machineno)) return;
 
-        if (isset($this->machineno) && $this->machineno != '') {
-            $machine = MsMachine::where('machineno', 'ilike', '%' . $this->machineno)
-                ->whereIn('department_id', departmentHelper::seitaiDepartment())
-                ->orderBy('machineno', 'ASC')
-                ->first();
-            if ($machine == null) {
-                $this->dispatch('notification', ['type' => 'warning', 'message' => 'Machine ' . $this->machineno . ' Tidak Terdaftar']);
-                $this->machinename = '';
-                $this->machineno = '';
-            } else {
-                $this->machineno = $machine->machineno;
-                $this->machinename = $machine->machinename;
-            }
+        $machine = MsMachine::where('machineno', 'ilike', '%' . $machineno)
+            ->whereIn('department_id', departmentHelper::seitaiDepartment())
+            ->orderBy('machineno', 'ASC')
+            ->first();
+
+        if (!$machine) {
+            $this->dispatch('notification', ['type' => 'warning', 'message' => 'Machine ' . $machineno . ' Tidak Terdaftar']);
+            $this->machinename = $this->machineno = '';
+        } else {
+            $this->machineno   = $machine->machineno;
+            $this->machinename = $machine->machinename;
         }
     }
 
-    public function updatedEmployeeno($employeeno)
+    public function updatedEmployeeno($employeeno): void
     {
         $this->employeeno = $employeeno;
+        if (empty($employeeno) || strlen($employeeno) < 3) return;
 
-        if (isset($this->employeeno) && $this->employeeno != '' && strlen($this->employeeno) >= 3) {
-            $msemployee = MsEmployee::where('employeeno', 'ilike', '%' . $this->employeeno)->active()->first();
-
-            if ($msemployee == null) {
-                $this->empname = '';
-                $this->dispatch('notification', ['type' => 'warning', 'message' => 'Employee ' . $this->employeeno . ' Tidak Terdaftar']);
-            } else {
-                $this->employeeno = $msemployee->employeeno;
-                $this->empname = $msemployee->empname;
-            }
+        $msemployee = MsEmployee::where('employeeno', 'ilike', '%' . $employeeno)->active()->first();
+        if (!$msemployee) {
+            $this->empname = '';
+            $this->dispatch('notification', ['type' => 'warning', 'message' => 'Employee ' . $employeeno . ' Tidak Terdaftar']);
+        } else {
+            $this->employeeno = $msemployee->employeeno;
+            $this->empname    = $msemployee->empname;
         }
-    }
-
-    public function getData()
-    {
-        $data = DB::table('tdjamkerjamesin AS tdjkm')
-            ->select(
-                'tdjkm.id',
-                'tdjkm.working_date',
-                'tdjkm.work_shift',
-                'tdjkm.work_hour',
-                'tdjkm.off_hour',
-                'tdjkm.on_hour',
-                'tdjkm.updated_by',
-                'tdjkm.updated_on',
-                'tdjkm.created_on',
-                'msm.machineno',
-                'mse.empname',
-                'mse.employeeno',
-            )
-            ->leftJoin('msmachine AS msm', 'msm.id', '=', 'tdjkm.machine_id')
-            ->leftJoin('msemployee AS mse', 'mse.id', '=', 'tdjkm.employee_id')
-            ->whereIn('tdjkm.department_id', departmentHelper::seitaiDivision());
-
-        if ($this->transaksi == 1) {
-            if (isset($this->tglMasuk) && $this->tglMasuk != "" && $this->tglMasuk != "undefined") {
-                $data = $data->where('tdjkm.working_date', '>=', $this->tglMasuk);
-            }
-
-            if (isset($this->tglKeluar) && $this->tglKeluar != "" && $this->tglKeluar != "undefined") {
-                $data = $data->where('tdjkm.working_date', '<=', $this->tglKeluar);
-            }
-        } else if ($this->transaksi == 2) {
-            if (isset($this->tglMasuk) && $this->tglMasuk != "" && $this->tglMasuk != "undefined") {
-                $data = $data->where('tdjkm.created_on', '>=', $this->tglMasuk . " 00:00:00");
-            }
-
-            if (isset($this->tglKeluar) && $this->tglKeluar != "" && $this->tglKeluar != "undefined") {
-                $data = $data->where('tdjkm.created_on', '<=', $this->tglKeluar . " 23:59:59");
-            }
-        }
-
-        if (isset($this->machine_id) && $this->machine_id['value'] != "" && $this->machine_id != "undefined") {
-            $data = $data->where('tdjkm.machine_id', $this->machine_id['value']);
-        }
-        if (isset($this->work_shift_filter) && $this->work_shift_filter['value'] != "" && $this->work_shift_filter != "undefined") {
-            $data = $data->where('tdjkm.work_shift', $this->work_shift_filter);
-        }
-        if (isset($this->searchTerm) && $this->searchTerm != '') {
-            $data = $data->where(function ($query) {
-                $query->where('msm.machineno', 'ilike', '%' . $this->searchTerm . '%')
-                    ->orWhere('msm.machinename', 'ilike', '%' . $this->searchTerm . '%');
-            });
-        }
-        $this->data = $data->orderBy('tdjkm.updated_on', 'DESC')->get();
     }
 
     public function export()
     {
         $this->startHeavyJob();
-        // validasi
         if ($this->tglMasuk == $this->tglKeluar) {
             $this->dispatch('notification', ['type' => 'warning', 'message' => 'Tanggal Masuk dan Tanggal Keluar tidak boleh sama']);
             return;
-        } else if (Carbon::parse($this->tglMasuk) > Carbon::parse($this->tglKeluar)) {
+        }
+        if (Carbon::parse($this->tglMasuk) > Carbon::parse($this->tglKeluar)) {
             $this->dispatch('notification', ['type' => 'warning', 'message' => 'Tanggal Masuk tidak boleh lebih besar dari Tanggal Keluar']);
             return;
         }
 
-        $tglMasuk = Carbon::parse($this->tglMasuk . " 07:01:00");
-        $tglKeluar = Carbon::parse($this->tglKeluar . " 07:00:00");
         $filter = [
-            'machine_id' => $this->machine_id['value'] ?? null,
-            'work_shift' => $this->work_shift_filter['value'] ?? null,
+            'machine_id' => $this->machine_id ?? null,
+            'work_shift' => $this->work_shift_filter ?? null,
             'searchTerm' => $this->searchTerm ?? null,
-            'transaksi' => $this->transaksi ?? 1,
+            'transaksi'  => $this->transaksi ?? 1,
         ];
 
         $checklist = new CheckListJamKerjaController();
-        $response = $checklist->checklistJamKerja($tglMasuk, $tglKeluar, $filter, 'SEITAI');
-        if ($response['status'] == 'success') {
+        $response  = $checklist->checklistJamKerja(
+            Carbon::parse($this->tglMasuk . ' 07:01:00'),
+            Carbon::parse($this->tglKeluar . ' 07:00:00'),
+            $filter,
+            'SEITAI'
+        );
+        if ($response['status'] === 'success') {
             return response()->download($response['filename']);
-        } else if ($response['status'] == 'error') {
-            $this->dispatch('notification', ['type' => 'warning', 'message' => $response['message']]);
-            return;
         }
+        $this->dispatch('notification', ['type' => 'warning', 'message' => $response['message']]);
     }
 
     public function render()
     {
-        return view('livewire.jam-kerja.seitai', [
-            'data' => $this->data
-        ])->extends('layouts.master');
-    }
+        $machine = Cache::remember('ms_machines_seitai_jk', 3600, fn() =>
+            MsMachine::whereIn('department_id', departmentHelper::seitaiPabrikDepartment()->pluck('id'))
+                ->select(['id', 'machineno', 'machinename'])
+                ->get()
+        );
+        $workShift = Cache::remember('ms_workshifts_jk', 3600, fn() =>
+            MsWorkingShift::active()->select(['id', 'work_shift'])->get()
+        );
 
-    public function rendered()
-    {
-        if (!$this->isUpdatingSorting && !$this->jamMatiDataUpdated) {
-            $this->dispatch('initDataTable');
+        if (!$this->isLoaded) {
+            return view('livewire.jam-kerja.seitai', [
+                'data'      => new \Illuminate\Pagination\LengthAwarePaginator([], 0, $this->perPage),
+                'machine'   => $machine,
+                'workShift' => $workShift,
+            ])->extends('layouts.master');
         }
+
+        try {
+            $data = DB::table('tdjamkerjamesin AS tdjkm')
+                ->select([
+                    'tdjkm.id',
+                    'tdjkm.working_date',
+                    'tdjkm.work_shift',
+                    'tdjkm.work_hour',
+                    'tdjkm.off_hour',
+                    'tdjkm.on_hour',
+                    'tdjkm.updated_by',
+                    'tdjkm.updated_on',
+                    'tdjkm.created_on',
+                    'msm.machineno',
+                    'mse.empname',
+                    'mse.employeeno',
+                ])
+                ->leftJoin('msmachine AS msm', 'msm.id', '=', 'tdjkm.machine_id')
+                ->leftJoin('msemployee AS mse', 'mse.id', '=', 'tdjkm.employee_id')
+                ->whereIn('tdjkm.department_id', departmentHelper::seitaiDivision());
+
+            $dateColumn = $this->transaksi == 2 ? 'tdjkm.created_on' : 'tdjkm.working_date';
+            if (!empty($this->tglMasuk) && $this->tglMasuk !== 'undefined') {
+                $suffix = $this->transaksi == 2 ? ' 00:00:00' : '';
+                $data->where($dateColumn, '>=', $this->tglMasuk . $suffix);
+            }
+            if (!empty($this->tglKeluar) && $this->tglKeluar !== 'undefined') {
+                $suffix = $this->transaksi == 2 ? ' 23:59:59' : '';
+                $data->where($dateColumn, '<=', $this->tglKeluar . $suffix);
+            }
+            if (!empty($this->machine_id) && $this->machine_id !== 'undefined') {
+                $data->where('tdjkm.machine_id', $this->machine_id);
+            }
+            if (!empty($this->work_shift_filter) && $this->work_shift_filter !== 'undefined') {
+                $data->where('tdjkm.work_shift', $this->work_shift_filter);
+            }
+            if (!empty($this->searchTerm) && $this->searchTerm !== 'undefined') {
+                $data->where(function ($q) {
+                    $q->where('msm.machineno', 'ilike', '%' . $this->searchTerm . '%')
+                      ->orWhere('msm.machinename', 'ilike', '%' . $this->searchTerm . '%');
+                });
+            }
+
+            $data = $data->orderBy($this->sortColumn, $this->sortDirection)
+                         ->paginate($this->perPage);
+        } catch (\Exception $e) {
+            $data = new \Illuminate\Pagination\LengthAwarePaginator([], 0, $this->perPage);
+            $this->dispatch('notification', ['type' => 'error', 'message' => 'Terjadi kesalahan: ' . $e->getMessage()]);
+        }
+
+        return view('livewire.jam-kerja.seitai', [
+            'data'      => $data,
+            'machine'   => $machine,
+            'workShift' => $workShift,
+        ])->extends('layouts.master');
     }
 
     protected function notify(string $type, string $message): void

--- a/resources/views/livewire/jam-kerja/infure.blade.php
+++ b/resources/views/livewire/jam-kerja/infure.blade.php
@@ -1,4 +1,17 @@
-<div>
+<div wire:init="loadData">
+    @if (!$isLoaded)
+        <div>
+            <div class="placeholder-glow mb-3" style="height:80px">
+                <span class="placeholder col-12 rounded" style="height:80px"></span>
+            </div>
+            <div style="overflow:hidden;border-radius:4px">
+                @for ($i = 0; $i < 8; $i++)
+                    <div style="height:36px;margin-bottom:2px;border-radius:3px;background:linear-gradient(90deg,#e9ecef 25%,#f8f9fa 50%,#e9ecef 75%);background-size:200% 100%;animation:ijk-bar-slide 1.2s {{ $i * 0.1 }}s infinite linear"></div>
+                @endfor
+            </div>
+            <style>@keyframes ijk-bar-slide{0%{background-position:200% 0}100%{background-position:-200% 0}}</style>
+        </div>
+    @else
     <div class="row filter-section">
         <div class="col-12 col-lg-7">
             <div class="row">
@@ -17,17 +30,10 @@
                             <div class="col-9">
                                 <div class="form-group">
                                     <div class="input-group">
-                                        <input wire:model.defer="tglMasuk" type="text" class="form-control"
-                                            style="padding:0.44rem" data-provider="flatpickr" data-date-format="d-m-Y">
-                                        <span class="input-group-text py-0">
-                                            <i class="ri-calendar-event-fill fs-4"></i>
-                                        </span>
-
-                                        <input wire:model.defer="tglKeluar" type="text" class="form-control"
-                                            style="padding:0.44rem" data-provider="flatpickr" data-date-format="d-m-Y">
-                                        <span class="input-group-text py-0">
-                                            <i class="ri-calendar-event-fill fs-4"></i>
-                                        </span>
+                                        <input wire:model.defer="tglMasuk" type="date" class="form-control"
+                                            style="padding:0.44rem" value="{{ $tglMasuk }}">
+                                        <input wire:model.defer="tglKeluar" type="date" class="form-control"
+                                            style="padding:0.44rem" value="{{ $tglKeluar }}">
                                     </div>
                                 </div>
                             </div>
@@ -53,11 +59,10 @@
                 </div>
                 <div class="col-12 col-lg-10">
                     <div class="mb-1" wire:ignore>
-                        <select class="form-control" wire:model.defer="machine_id" data-choices
-                            data-choices-sorting-false data-choices-removeItem data-choices-search-field-label>
+                        <select class="form-control select2-machine-ijk">
                             <option value="">- All -</option>
                             @foreach ($machine as $item)
-                                <option value="{{ $item->id }}" @if ($item->id == ($machine_id['value'] ?? null)) selected @endif>
+                                <option value="{{ $item->id }}" @if ($item->id == ($machine_id ?? null)) selected @endif>
                                     {{ $item->machineno }}</option>
                             @endforeach
                         </select>
@@ -68,11 +73,10 @@
                 </div>
                 <div class="col-12 col-lg-10">
                     <div class="mb-1" wire:ignore>
-                        <select class="form-control" wire:model.defer="work_shift_filter" data-choices
-                            data-choices-sorting-false data-choices-removeItem data-choices-search-field-label>
+                        <select class="form-control select2-shift-ijk">
                             <option value="">- All -</option>
                             @foreach ($workShift as $item)
-                                <option value="{{ $item->id }}" @if ($item->id == ($work_shift_filter['value'] ?? null)) selected @endif>
+                                <option value="{{ $item->id }}" @if ($item->id == ($work_shift_filter ?? null)) selected @endif>
                                     Shift-{{ $item->work_shift }}</option>
                             @endforeach
                         </select>
@@ -121,8 +125,8 @@
                                             <div class="form-group" style="margin-left:1px; white-space:nowrap">
                                                 <div class="input-group">
                                                     <input class="form-control" style="padding:0.44rem" autocomplete="off"
-                                                        data-provider="flatpickr" data-date-format="d-m-Y" data-max-date="{{ now()->format('d-m-Y') }}"
-                                                        type="text" wire:model.defer="working_date" placeholder="yyyy/mm/dd" />
+                                                        type="date" wire:model.defer="working_date"
+                                                        max="{{ now()->format('Y-m-d') }}" />
                                                     <span class="input-group-text py-0">
                                                         <i class="ri-calendar-event-fill fs-4"></i>
                                                     </span>
@@ -655,157 +659,144 @@
         </div>
     </div>
 
-    <div class="table-responsive table-card  mt-2  mb-2">
-        {{-- toggle column table --}}
-        <div class="col text-end dropdown">
-            <button type="button" data-bs-toggle="dropdown" aria-expanded="false"
-                class="btn btn-soft-primary btn-icon fs-14 mt-2">
-                <i class="ri-grid-fill"></i>
-            </button>
-            <ul class="dropdown-menu dropdown-menu-end">
-                <li>
-                    <label style="cursor: pointer;">
-                        <input class="form-check-input fs-15 ms-2 toggle-column" type="checkbox" data-column="1"
-                            checked> Tanggal
-                    </label>
-                </li>
-                <li>
-                    <label style="cursor: pointer;">
-                        <input class="form-check-input fs-15 ms-2 toggle-column" type="checkbox" data-column="2"
-                            checked> Shift
-                    </label>
-                </li>
-                <li>
-                    <label style="cursor: pointer;">
-                        <input class="form-check-input fs-15 ms-2 toggle-column" type="checkbox" data-column="3"
-                            checked> Nomor Mesin
-                    </label>
-                </li>
-                <li>
-                    <label style="cursor: pointer;">
-                        <input class="form-check-input fs-15 ms-2 toggle-column" type="checkbox" data-column="4"
-                            checked> NIK
-                    </label>
-                </li>
-                <li>
-                    <label style="cursor: pointer;">
-                        <input class="form-check-input fs-15 ms-2 toggle-column" type="checkbox" data-column="5"
-                            checked> Petugas
-                    </label>
-                </li>
-                <li>
-                    <label style="cursor: pointer;">
-                        <input class="form-check-input fs-15 ms-2 toggle-column" type="checkbox" data-column="6"
-                            checked> Jam Kerja
-                    </label>
-                </li>
-                <li>
-                    <label style="cursor: pointer;">
-                        <input class="form-check-input fs-15 ms-2 toggle-column" type="checkbox" data-column="7"
-                            checked> Jam Mati
-                    </label>
-                </li>
-                <li>
-                    <label style="cursor: pointer;">
-                        <input class="form-check-input fs-15 ms-2 toggle-column" type="checkbox" data-column="8"
-                            checked> Jam Jalan
-                    </label>
-                </li>
-                <li>
-                    <label style="cursor: pointer;">
-                        <input class="form-check-input fs-15 ms-2 toggle-column" type="checkbox" data-column="10"
-                            checked> Update By
-                    </label>
-                </li>
-                <li>
-                    <label style="cursor: pointer;">
-                        <input class="form-check-input fs-15 ms-2 toggle-column" type="checkbox" data-column="11"
-                            checked> Updated
-                    </label>
-                </li>
-                <li>
-                    <label style="cursor: pointer;">
-                        <input class="form-check-input fs-15 ms-2 toggle-column" type="checkbox" data-column="12"
-                            checked> Created
-                    </label>
-                </li>
-            </ul>
+    <div x-data="{
+        cols: {1:true,2:true,3:true,4:true,5:true,6:true,7:true,8:true,9:true,10:true,11:true}
+    }" class="mt-2 mb-2">
+        <div class="d-flex justify-content-between align-items-center mb-1 flex-wrap gap-2">
+            <div class="d-flex align-items-center gap-2">
+                <label class="text-muted small mb-0">Show</label>
+                <select wire:model.live="perPage" class="form-select form-select-sm" style="width:auto">
+                    <option value="10">10</option>
+                    <option value="25">25</option>
+                    <option value="50">50</option>
+                    <option value="100">100</option>
+                </select>
+                <label class="text-muted small mb-0">entries</label>
+            </div>
+            <div class="dropdown">
+                <button type="button" data-bs-toggle="dropdown" class="btn btn-soft-primary btn-icon fs-14">
+                    <i class="ri-grid-fill"></i>
+                </button>
+                <ul class="dropdown-menu dropdown-menu-end" style="min-width:160px">
+                    <li><label class="dropdown-item" style="cursor:pointer"><input type="checkbox" x-model="cols[1]" class="form-check-input me-1"> Tanggal</label></li>
+                    <li><label class="dropdown-item" style="cursor:pointer"><input type="checkbox" x-model="cols[2]" class="form-check-input me-1"> Shift</label></li>
+                    <li><label class="dropdown-item" style="cursor:pointer"><input type="checkbox" x-model="cols[3]" class="form-check-input me-1"> Nomor Mesin</label></li>
+                    <li><label class="dropdown-item" style="cursor:pointer"><input type="checkbox" x-model="cols[4]" class="form-check-input me-1"> NIK</label></li>
+                    <li><label class="dropdown-item" style="cursor:pointer"><input type="checkbox" x-model="cols[5]" class="form-check-input me-1"> Petugas</label></li>
+                    <li><label class="dropdown-item" style="cursor:pointer"><input type="checkbox" x-model="cols[6]" class="form-check-input me-1"> Jam Kerja</label></li>
+                    <li><label class="dropdown-item" style="cursor:pointer"><input type="checkbox" x-model="cols[7]" class="form-check-input me-1"> Jam Mati</label></li>
+                    <li><label class="dropdown-item" style="cursor:pointer"><input type="checkbox" x-model="cols[8]" class="form-check-input me-1"> Jam Jalan</label></li>
+                    <li><label class="dropdown-item" style="cursor:pointer"><input type="checkbox" x-model="cols[9]" class="form-check-input me-1"> Update By</label></li>
+                    <li><label class="dropdown-item" style="cursor:pointer"><input type="checkbox" x-model="cols[10]" class="form-check-input me-1"> Updated</label></li>
+                    <li><label class="dropdown-item" style="cursor:pointer"><input type="checkbox" x-model="cols[11]" class="form-check-input me-1"> Created</label></li>
+                </ul>
+            </div>
         </div>
-        <table class="table align-middle" id="infureTable">
-            <thead class="table-light">
-                <tr>
-                    <th>Action</th>
-                    <th>Tanggal</th>
-                    <th>Shift</th>
-                    <th>Nomor Mesin</th>
-                    <th>NIK</th>
-                    <th>Petugas</th>
-                    <th>Jam Kerja</th>
-                    <th>Jam Mati</th>
-                    <th>Jam Jalan</th>
-                    <th>Update By</th>
-                    <th>Updated</th>
-                    <th>Created</th>
-                </tr>
-            </thead>
-            <tbody class="list form-check-all">
-                @forelse ($data as $item)
+
+        <div wire:loading.class="opacity-50"
+             wire:target="search,sortBy,gotoPage,nextPage,previousPage,perPage"
+             style="overflow-x:auto; overflow-y:auto; max-height:65vh; transition:opacity 0.15s;">
+            <table class="table align-middle table-nowrap table-hover" id="infureTable">
+                <thead class="table-light">
                     <tr>
-                        <td>
-                            <button type="button" class="btn fs-15 p-1 bg-primary rounded btn-edit"
-                                data-edit-id="{{ $item->id }}" wire:click="edit({{ $item->id }})">
-                                <i class="ri-edit-box-line text-white"></i>
-                            </button>
-                            <button type="button" class="btn fs-15 p-1 bg-danger rounded btn-delete"
-                                data-delete-id="{{ $item->id }}" wire:click="delete({{ $item->id }})">
-                                <i class="ri-delete-bin-line text-white"></i>
-                            </button>
-                        </td>
-                        <td>{{ \Carbon\Carbon::parse($item->working_date)->format('d M Y') }}</td>
-                        <td>{{ $item->work_shift }}</td>
-                        <td>{{ $item->machineno }}</td>
-                        <td> {{ $item->employeeno }}</td>
-                        <td> {{ $item->empname }}</td>
-                        <td>{{ $item->work_hour }}</td>
-                        <td>{{ $item->off_hour }}</td>
-                        <td>{{ $item->on_hour }}</td>
-                        <td>{{ $item->updated_by }}</td>
-                        <td>{{ \Carbon\Carbon::parse($item->updated_on)->format('d M Y H:i:s') }}</td>
-                        <td>{{ \Carbon\Carbon::parse($item->created_on)->format('d M Y H:i:s') }}</td>
+                        <th style="width:80px">Action</th>
+                        <th :class="{'d-none': !cols[1]}" wire:click="sortBy('tdjkm.working_date')" style="cursor:pointer;white-space:nowrap">
+                            Tanggal <i class="{{ $sortColumn === 'tdjkm.working_date' ? ($sortDirection === 'asc' ? 'ri-arrow-up-s-line text-primary' : 'ri-arrow-down-s-line text-primary') : 'ri-expand-up-down-line text-muted' }} fs-12"></i>
+                        </th>
+                        <th :class="{'d-none': !cols[2]}" wire:click="sortBy('tdjkm.work_shift')" style="cursor:pointer;white-space:nowrap">
+                            Shift <i class="{{ $sortColumn === 'tdjkm.work_shift' ? ($sortDirection === 'asc' ? 'ri-arrow-up-s-line text-primary' : 'ri-arrow-down-s-line text-primary') : 'ri-expand-up-down-line text-muted' }} fs-12"></i>
+                        </th>
+                        <th :class="{'d-none': !cols[3]}" wire:click="sortBy('msm.machineno')" style="cursor:pointer;white-space:nowrap">
+                            Nomor Mesin <i class="{{ $sortColumn === 'msm.machineno' ? ($sortDirection === 'asc' ? 'ri-arrow-up-s-line text-primary' : 'ri-arrow-down-s-line text-primary') : 'ri-expand-up-down-line text-muted' }} fs-12"></i>
+                        </th>
+                        <th :class="{'d-none': !cols[4]}" wire:click="sortBy('mse.employeeno')" style="cursor:pointer;white-space:nowrap">
+                            NIK <i class="{{ $sortColumn === 'mse.employeeno' ? ($sortDirection === 'asc' ? 'ri-arrow-up-s-line text-primary' : 'ri-arrow-down-s-line text-primary') : 'ri-expand-up-down-line text-muted' }} fs-12"></i>
+                        </th>
+                        <th :class="{'d-none': !cols[5]}" wire:click="sortBy('mse.empname')" style="cursor:pointer;white-space:nowrap">
+                            Petugas <i class="{{ $sortColumn === 'mse.empname' ? ($sortDirection === 'asc' ? 'ri-arrow-up-s-line text-primary' : 'ri-arrow-down-s-line text-primary') : 'ri-expand-up-down-line text-muted' }} fs-12"></i>
+                        </th>
+                        <th :class="{'d-none': !cols[6]}" wire:click="sortBy('tdjkm.work_hour')" style="cursor:pointer;white-space:nowrap">
+                            Jam Kerja <i class="{{ $sortColumn === 'tdjkm.work_hour' ? ($sortDirection === 'asc' ? 'ri-arrow-up-s-line text-primary' : 'ri-arrow-down-s-line text-primary') : 'ri-expand-up-down-line text-muted' }} fs-12"></i>
+                        </th>
+                        <th :class="{'d-none': !cols[7]}" wire:click="sortBy('tdjkm.off_hour')" style="cursor:pointer;white-space:nowrap">
+                            Jam Mati <i class="{{ $sortColumn === 'tdjkm.off_hour' ? ($sortDirection === 'asc' ? 'ri-arrow-up-s-line text-primary' : 'ri-arrow-down-s-line text-primary') : 'ri-expand-up-down-line text-muted' }} fs-12"></i>
+                        </th>
+                        <th :class="{'d-none': !cols[8]}" wire:click="sortBy('tdjkm.on_hour')" style="cursor:pointer;white-space:nowrap">
+                            Jam Jalan <i class="{{ $sortColumn === 'tdjkm.on_hour' ? ($sortDirection === 'asc' ? 'ri-arrow-up-s-line text-primary' : 'ri-arrow-down-s-line text-primary') : 'ri-expand-up-down-line text-muted' }} fs-12"></i>
+                        </th>
+                        <th :class="{'d-none': !cols[9]}" style="white-space:nowrap">Update By</th>
+                        <th :class="{'d-none': !cols[10]}" wire:click="sortBy('tdjkm.updated_on')" style="cursor:pointer;white-space:nowrap">
+                            Updated <i class="{{ $sortColumn === 'tdjkm.updated_on' ? ($sortDirection === 'asc' ? 'ri-arrow-up-s-line text-primary' : 'ri-arrow-down-s-line text-primary') : 'ri-expand-up-down-line text-muted' }} fs-12"></i>
+                        </th>
+                        <th :class="{'d-none': !cols[11]}" wire:click="sortBy('tdjkm.created_on')" style="cursor:pointer;white-space:nowrap">
+                            Created <i class="{{ $sortColumn === 'tdjkm.created_on' ? ($sortDirection === 'asc' ? 'ri-arrow-up-s-line text-primary' : 'ri-arrow-down-s-line text-primary') : 'ri-expand-up-down-line text-muted' }} fs-12"></i>
+                        </th>
                     </tr>
-                @empty
-                @endforelse
-            </tbody>
-        </table>
+                </thead>
+                <tbody>
+                    @forelse ($data as $item)
+                        <tr>
+                            <td>
+                                <button type="button" class="btn fs-15 p-1 bg-primary rounded"
+                                    wire:click="edit({{ $item->id }})">
+                                    <i class="ri-edit-box-line text-white"></i>
+                                </button>
+                                <button type="button" class="btn fs-15 p-1 bg-danger rounded"
+                                    wire:click="delete({{ $item->id }})">
+                                    <i class="ri-delete-bin-line text-white"></i>
+                                </button>
+                            </td>
+                            <td :class="{'d-none': !cols[1]}">{{ \Carbon\Carbon::parse($item->working_date)->format('d M Y') }}</td>
+                            <td :class="{'d-none': !cols[2]}">{{ $item->work_shift }}</td>
+                            <td :class="{'d-none': !cols[3]}">{{ $item->machineno }}</td>
+                            <td :class="{'d-none': !cols[4]}">{{ $item->employeeno }}</td>
+                            <td :class="{'d-none': !cols[5]}">{{ $item->empname }}</td>
+                            <td :class="{'d-none': !cols[6]}">{{ $item->work_hour }}</td>
+                            <td :class="{'d-none': !cols[7]}">{{ $item->off_hour }}</td>
+                            <td :class="{'d-none': !cols[8]}">{{ $item->on_hour }}</td>
+                            <td :class="{'d-none': !cols[9]}">{{ $item->updated_by }}</td>
+                            <td :class="{'d-none': !cols[10]}">{{ \Carbon\Carbon::parse($item->updated_on)->format('d M Y H:i:s') }}</td>
+                            <td :class="{'d-none': !cols[11]}">{{ \Carbon\Carbon::parse($item->created_on)->format('d M Y H:i:s') }}</td>
+                        </tr>
+                    @empty
+                        <tr>
+                            <td colspan="12" class="text-center py-4">
+                                <lord-icon src="https://cdn.lordicon.com/msoeawqm.json" trigger="loop"
+                                    colors="primary:#121331,secondary:#08a88a" style="width:40px;height:40px"></lord-icon>
+                                <h5 class="mt-2">Record not Found..!</h5>
+                            </td>
+                        </tr>
+                    @endforelse
+                </tbody>
+            </table>
+        </div>
+
+        <div class="d-flex justify-content-between align-items-center flex-wrap mt-2 gap-2">
+            <div class="text-muted small">
+                @if ($data instanceof \Illuminate\Pagination\LengthAwarePaginator)
+                    Showing {{ $data->firstItem() ?? 0 }}–{{ $data->lastItem() ?? 0 }} of {{ $data->total() }} entries
+                @endif
+            </div>
+            <div>
+                @if ($data instanceof \Illuminate\Pagination\LengthAwarePaginator)
+                    {{ $data->links() }}
+                @endif
+            </div>
+        </div>
     </div>
 
     <style>
-        .modal-overlay-top {
-            z-index: 1060;
-            /* default Bootstrap modal z-index is 1055 */
-        }
-
+        .modal-overlay-top { z-index: 1060; }
         .modal-backdrop-custom {
-            position: fixed;
-            top: 0;
-            left: 0;
-            width: 100vw;
-            height: 100vh;
-            background-color: rgba(0, 0, 0, 0.5);
-            /* gelap transparan */
-            z-index: 1058;
-            /* di bawah modal-jam-mati, tapi di atas modal-jam-kerja */
+            position: fixed; top: 0; left: 0; width: 100vw; height: 100vh;
+            background-color: rgba(0,0,0,0.5); z-index: 1058;
         }
-
-        #infureTable.table>:not(caption)>*>* {
+        #infureTable.table > :not(caption) > * > * {
             font-size: 13px !important;
             padding: 4px 2px 4px 4px;
-            color: var(--tb-table-color-state, var(--tb-table-color-type, var(--tb-table-color)));
-            background-color: var(--tb-table-bg);
-            border-bottom-width: var(--tb-border-width);
-            box-shadow: inset 0 0 0 9999px var(--tb-table-bg-state, var(--tb-table-bg-type, var(--tb-table-accent-bg)));
         }
     </style>
+    @endif
 </div>
 
 @script
@@ -891,101 +882,38 @@
             $('#removModal').modal('hide');
         });
 
-        // datatable
-        // inisialisasi DataTable
-        $wire.on('initDataTable', () => {
-            initDataTable();
+        document.addEventListener('livewire:initialized', function() {
+            function initMachineSelect() {
+                if ($('.select2-machine-ijk').hasClass('select2-hidden-accessible')) {
+                    $('.select2-machine-ijk').select2('destroy');
+                }
+                $('.select2-machine-ijk').select2({
+                    theme: 'bootstrap-5', allowClear: true, placeholder: '- All -',
+                }).on('change', function() {
+                    @this.set('machine_id', $(this).val() || null);
+                });
+            }
+
+            function initShiftSelect() {
+                if ($('.select2-shift-ijk').hasClass('select2-hidden-accessible')) {
+                    $('.select2-shift-ijk').select2('destroy');
+                }
+                $('.select2-shift-ijk').select2({
+                    theme: 'bootstrap-5', allowClear: true, placeholder: '- All -',
+                }).on('change', function() {
+                    @this.set('work_shift_filter', $(this).val() || null);
+                });
+            }
+
+            initMachineSelect();
+            initShiftSelect();
+
+            Livewire.hook('morph', ({ el, component }) => {
+                setTimeout(() => {
+                    initMachineSelect();
+                    initShiftSelect();
+                }, 100);
+            });
         });
-
-        function calculateTableHeight() {
-            const totalHeight = window.innerHeight;
-
-            const filterSectionTop = document.querySelector('.filter-section')?.getBoundingClientRect().top || 0;
-            const offsetTop = document.querySelector('#infureTable')?.getBoundingClientRect().top || 0;
-
-            const paddingTop = document.querySelector('.navbar-header')?.getBoundingClientRect().top || 0;
-            const availableHeight = totalHeight - offsetTop - filterSectionTop - paddingTop;
-
-            return availableHeight;
-        }
-
-        // Fungsi untuk menginisialisasi ulang DataTable
-        function initDataTable() {
-            const savedOrder = $wire.get('sortingTable');
-
-            let defaultOrder = [
-                [1, "asc"]
-            ];
-            if (savedOrder) {
-                defaultOrder = savedOrder;
-            }
-            // Hapus DataTable jika sudah ada
-            if ($.fn.dataTable.isDataTable('#infureTable')) {
-                let table = $('#infureTable').DataTable();
-                table.clear(); // Bersihkan data tabel
-                table.destroy(); // Hancurkan DataTable
-            }
-
-            setTimeout(() => {
-                // Inisialisasi ulang DataTable
-                let table = $('#infureTable').DataTable({
-                    "pageLength": 10,
-                    "searching": true,
-                    "responsive": true,
-                    "scrollX": true,
-                    "order": defaultOrder,
-                    "scrollY": calculateTableHeight() + 'px',
-                    "scrollCollapse": true,
-                    "scrollX": true,
-                    "language": {
-                        "emptyTable": `
-                            <div class="text-center">
-                                <lord-icon src="https://cdn.lordicon.com/msoeawqm.json" trigger="loop"
-                                    colors="primary:#121331,secondary:#08a88a" style="width:40px;height:40px"></lord-icon>
-                                <h5 class="mt-2">Sorry! No Result Found</h5>
-                            </div>
-                        `
-                    }
-                });
-                // tombol edit
-                $('.btn-edit').on('click', function() {
-                    let id = $(this).attr('data-edit-id');
-
-                    // livewire click
-                    $wire.dispatch('edit', {
-                        id
-                    });
-                });
-                // tombol delete
-                $('.btn-delete').on('click', function() {
-                    let id = $(this).attr('data-delete-id');
-
-                    // livewire click
-                    $wire.dispatch('delete', {
-                        id
-                    });
-                });
-                // Listen to sort event
-                table.on('order.dt', function() {
-                    let order = table.order();
-                    if (order.length == 0 && defaultOrder.length > 0) {
-                        order = defaultOrder;
-                    }
-                    $wire.call('updateSortingTable', order);
-                });
-
-                // default column visibility
-                $('.toggle-column').each(function() {
-                    let column = table.column($(this).attr('data-column'));
-                    column.visible($(this).is(':checked'));
-                });
-
-                // Inisialisasi ulang event listener checkbox
-                $('.toggle-column').off('change').on('change', function() {
-                    let column = table.column($(this).attr('data-column'));
-                    column.visible(!column.visible());
-                });
-            }, 500);
-        }
     </script>
 @endscript

--- a/resources/views/livewire/jam-kerja/seitai.blade.php
+++ b/resources/views/livewire/jam-kerja/seitai.blade.php
@@ -1,4 +1,17 @@
-<div>
+<div wire:init="loadData">
+    @if (!$isLoaded)
+        <div>
+            <div class="placeholder-glow mb-3" style="height:80px">
+                <span class="placeholder col-12 rounded" style="height:80px"></span>
+            </div>
+            <div style="overflow:hidden;border-radius:4px">
+                @for ($i = 0; $i < 8; $i++)
+                    <div style="height:36px;margin-bottom:2px;border-radius:3px;background:linear-gradient(90deg,#e9ecef 25%,#f8f9fa 50%,#e9ecef 75%);background-size:200% 100%;animation:sjk-bar-slide 1.2s {{ $i * 0.1 }}s infinite linear"></div>
+                @endfor
+            </div>
+            <style>@keyframes sjk-bar-slide{0%{background-position:200% 0}100%{background-position:-200% 0}}</style>
+        </div>
+    @else
     <div class="row filter-section">
         <div class="col-12 col-lg-7">
             <div class="row">
@@ -17,17 +30,10 @@
                             <div class="col-9">
                                 <div class="form-group">
                                     <div class="input-group">
-                                        <input wire:model.defer="tglMasuk" type="text" class="form-control"
-                                            style="padding:0.44rem" data-provider="flatpickr" data-date-format="d-m-Y">
-                                        <span class="input-group-text py-0">
-                                            <i class="ri-calendar-event-fill fs-4"></i>
-                                        </span>
-
-                                        <input wire:model.defer="tglKeluar" type="text" class="form-control"
-                                            style="padding:0.44rem" data-provider="flatpickr" data-date-format="d-m-Y">
-                                        <span class="input-group-text py-0">
-                                            <i class="ri-calendar-event-fill fs-4"></i>
-                                        </span>
+                                        <input wire:model.defer="tglMasuk" type="date" class="form-control"
+                                            style="padding:0.44rem" value="{{ $tglMasuk }}">
+                                        <input wire:model.defer="tglKeluar" type="date" class="form-control"
+                                            style="padding:0.44rem" value="{{ $tglKeluar }}">
                                     </div>
                                 </div>
                             </div>
@@ -53,11 +59,10 @@
                 </div>
                 <div class="col-12 col-lg-10">
                     <div class="mb-1" wire:ignore>
-                        <select class="form-control" wire:model.defer="machine_id" data-choices
-                            data-choices-sorting-false data-choices-removeItem data-choices-search-field-label>
+                        <select class="form-control select2-machine-sjk">
                             <option value="">- All -</option>
                             @foreach ($machine as $item)
-                                <option value="{{ $item->id }}" @if ($item->id == ($machine_id['value'] ?? null)) selected @endif>
+                                <option value="{{ $item->id }}" @if ($item->id == ($machine_id ?? null)) selected @endif>
                                     {{ $item->machineno }}</option>
                             @endforeach
                         </select>
@@ -68,11 +73,10 @@
                 </div>
                 <div class="col-12 col-lg-10">
                     <div class="mb-1" wire:ignore>
-                        <select class="form-control" wire:model.defer="work_shift_filter" data-choices
-                            data-choices-sorting-false data-choices-removeItem data-choices-search-field-label>
+                        <select class="form-control select2-shift-sjk">
                             <option value="">- All -</option>
                             @foreach ($workShift as $item)
-                                <option value="{{ $item->id }}" @if ($item->id == ($work_shift_filter['value'] ?? null)) selected @endif>
+                                <option value="{{ $item->id }}" @if ($item->id == ($work_shift_filter ?? null)) selected @endif>
                                     Shift-{{ $item->work_shift }}</option>
                             @endforeach
                         </select>
@@ -121,12 +125,8 @@
                                             <div class="form-group" style="margin-left:1px; white-space:nowrap">
                                                 <div class="input-group">
                                                     <input class="form-control" style="padding:0.44rem"
-                                                        data-provider="flatpickr" data-date-format="d-m-Y"
-                                                        type="text" wire:model.defer="working_date"
-                                                        placeholder="yyyy/mm/dd" />
-                                                    <span class="input-group-text py-0">
-                                                        <i class="ri-calendar-event-fill fs-4"></i>
-                                                    </span>
+                                                        type="date" wire:model.defer="working_date"
+                                                        max="{{ now()->format('Y-m-d') }}" />
                                                     @error('working_date')
                                                         <span class="invalid-feedback">{{ $message }}</span>
                                                     @enderror
@@ -656,164 +656,144 @@
         </div>
     </div>
 
-    <div class="table-responsive table-card  mt-2  mb-2">
-        {{-- toggle column table --}}
-        <div class="col text-end dropdown">
-            <button type="button" data-bs-toggle="dropdown" aria-expanded="false"
-                class="btn btn-soft-primary btn-icon fs-14 mt-2">
-                <i class="ri-grid-fill"></i>
-            </button>
-            <ul class="dropdown-menu dropdown-menu-end">
-                <li>
-                    <label style="cursor: pointer;">
-                        <input class="form-check-input fs-15 ms-2 toggle-column" type="checkbox" data-column="1"
-                            checked> Tanggal
-                    </label>
-                </li>
-                <li>
-                    <label style="cursor: pointer;">
-                        <input class="form-check-input fs-15 ms-2 toggle-column" type="checkbox" data-column="2"
-                            checked> Shift
-                    </label>
-                </li>
-                <li>
-                    <label style="cursor: pointer;">
-                        <input class="form-check-input fs-15 ms-2 toggle-column" type="checkbox" data-column="3"
-                            checked> Nomor Mesin
-                    </label>
-                </li>
-                <li>
-                    <label style="cursor: pointer;">
-                        <input class="form-check-input fs-15 ms-2 toggle-column" type="checkbox" data-column="4"
-                            checked> NIK
-                    </label>
-                </li>
-                <li>
-                    <label style="cursor: pointer;">
-                        <input class="form-check-input fs-15 ms-2 toggle-column" type="checkbox" data-column="5"
-                            checked> Petugas
-                    </label>
-                </li>
-                <li>
-                    <label style="cursor: pointer;">
-                        <input class="form-check-input fs-15 ms-2 toggle-column" type="checkbox" data-column="6"
-                            checked> Jam Kerja
-                    </label>
-                </li>
-                <li>
-                    <label style="cursor: pointer;">
-                        <input class="form-check-input fs-15 ms-2 toggle-column" type="checkbox" data-column="7"
-                            checked> Jam Mati
-                    </label>
-                </li>
-                <li>
-                    <label style="cursor: pointer;">
-                        <input class="form-check-input fs-15 ms-2 toggle-column" type="checkbox" data-column="8"
-                            checked> Jam Jalan
-                    </label>
-                </li>
-                {{-- <li>
-                    <label style="cursor: pointer;">
-                        <input class="form-check-input fs-15 ms-2 toggle-column" type="checkbox" data-column="9"
-                            checked> Jam Mati Mesin
-                    </label>
-                </li> --}}
-                <li>
-                    <label style="cursor: pointer;">
-                        <input class="form-check-input fs-15 ms-2 toggle-column" type="checkbox" data-column="10"
-                            checked> Update By
-                    </label>
-                </li>
-                <li>
-                    <label style="cursor: pointer;">
-                        <input class="form-check-input fs-15 ms-2 toggle-column" type="checkbox" data-column="11"
-                            checked> Updated
-                    </label>
-                </li>
-                <li>
-                    <label style="cursor: pointer;">
-                        <input class="form-check-input fs-15 ms-2 toggle-column" type="checkbox" data-column="12"
-                            checked> Created
-                    </label>
-                </li>
-            </ul>
+    <div x-data="{
+        cols: {1:true,2:true,3:true,4:true,5:true,6:true,7:true,8:true,9:true,10:true,11:true}
+    }" class="mt-2 mb-2">
+        <div class="d-flex justify-content-between align-items-center mb-1 flex-wrap gap-2">
+            <div class="d-flex align-items-center gap-2">
+                <label class="text-muted small mb-0">Show</label>
+                <select wire:model.live="perPage" class="form-select form-select-sm" style="width:auto">
+                    <option value="10">10</option>
+                    <option value="25">25</option>
+                    <option value="50">50</option>
+                    <option value="100">100</option>
+                </select>
+                <label class="text-muted small mb-0">entries</label>
+            </div>
+            <div class="dropdown">
+                <button type="button" data-bs-toggle="dropdown" class="btn btn-soft-primary btn-icon fs-14">
+                    <i class="ri-grid-fill"></i>
+                </button>
+                <ul class="dropdown-menu dropdown-menu-end" style="min-width:160px">
+                    <li><label class="dropdown-item" style="cursor:pointer"><input type="checkbox" x-model="cols[1]" class="form-check-input me-1"> Tanggal</label></li>
+                    <li><label class="dropdown-item" style="cursor:pointer"><input type="checkbox" x-model="cols[2]" class="form-check-input me-1"> Shift</label></li>
+                    <li><label class="dropdown-item" style="cursor:pointer"><input type="checkbox" x-model="cols[3]" class="form-check-input me-1"> Nomor Mesin</label></li>
+                    <li><label class="dropdown-item" style="cursor:pointer"><input type="checkbox" x-model="cols[4]" class="form-check-input me-1"> NIK</label></li>
+                    <li><label class="dropdown-item" style="cursor:pointer"><input type="checkbox" x-model="cols[5]" class="form-check-input me-1"> Petugas</label></li>
+                    <li><label class="dropdown-item" style="cursor:pointer"><input type="checkbox" x-model="cols[6]" class="form-check-input me-1"> Jam Kerja</label></li>
+                    <li><label class="dropdown-item" style="cursor:pointer"><input type="checkbox" x-model="cols[7]" class="form-check-input me-1"> Jam Mati</label></li>
+                    <li><label class="dropdown-item" style="cursor:pointer"><input type="checkbox" x-model="cols[8]" class="form-check-input me-1"> Jam Jalan</label></li>
+                    <li><label class="dropdown-item" style="cursor:pointer"><input type="checkbox" x-model="cols[9]" class="form-check-input me-1"> Update By</label></li>
+                    <li><label class="dropdown-item" style="cursor:pointer"><input type="checkbox" x-model="cols[10]" class="form-check-input me-1"> Updated</label></li>
+                    <li><label class="dropdown-item" style="cursor:pointer"><input type="checkbox" x-model="cols[11]" class="form-check-input me-1"> Created</label></li>
+                </ul>
+            </div>
         </div>
-        <table class="table align-middle" id="seitaiTable">
-            <thead class="table-light">
-                <tr>
-                    <th>Action</th>
-                    <th>Tanggal</th>
-                    <th>Shift</th>
-                    <th>Nomor Mesin</th>
-                    <th>NIK</th>
-                    <th>Petugas</th>
-                    <th>Jam Kerja</th>
-                    <th>Jam Mati</th>
-                    <th>Jam Jalan</th>
-                    {{-- <th>Jam Mati Mesin</th> --}}
-                    <th>Update By</th>
-                    <th>Updated</th>
-                    <th>Created</th>
-                </tr>
-            </thead>
-            <tbody class="list form-check-all">
-                @forelse ($data as $item)
+
+        <div wire:loading.class="opacity-50"
+             wire:target="search,sortBy,gotoPage,nextPage,previousPage,perPage"
+             style="overflow-x:auto; overflow-y:auto; max-height:65vh; transition:opacity 0.15s;">
+            <table class="table align-middle table-nowrap table-hover" id="seitaiTable">
+                <thead class="table-light">
                     <tr>
-                        <td>
-                            <button type="button" class="btn fs-15 p-1 bg-primary rounded btn-edit"
-                                data-edit-id="{{ $item->id }}" wire:click="edit({{ $item->id }})">
-                                <i class="ri-edit-box-line text-white"></i>
-                            </button>
-                            <button type="button" class="btn fs-15 p-1 bg-danger rounded btn-delete"
-                                data-delete-id="{{ $item->id }}" wire:click="delete({{ $item->id }})">
-                                <i class="ri-delete-bin-line text-white"></i>
-                            </button>
-                        </td>
-                        <td>{{ \Carbon\Carbon::parse($item->working_date)->format('d M Y') }}</td>
-                        <td>{{ $item->work_shift }}</td>
-                        <td>{{ $item->machineno }}</td>
-                        <td> {{ $item->employeeno }}</td>
-                        <td> {{ $item->empname }}</td>
-                        <td>{{ $item->work_hour }}</td>
-                        <td>{{ $item->off_hour }}</td>
-                        <td>{{ $item->on_hour }}</td>
-                        <td>{{ $item->updated_by }}</td>
-                        <td>{{ \Carbon\Carbon::parse($item->updated_on)->format('d M Y H:i:s') }}</td>
-                        <td>{{ \Carbon\Carbon::parse($item->created_on)->format('d M Y H:i:s') }}</td>
+                        <th style="width:80px">Action</th>
+                        <th :class="{'d-none': !cols[1]}" wire:click="sortBy('tdjkm.working_date')" style="cursor:pointer;white-space:nowrap">
+                            Tanggal <i class="{{ $sortColumn === 'tdjkm.working_date' ? ($sortDirection === 'asc' ? 'ri-arrow-up-s-line text-primary' : 'ri-arrow-down-s-line text-primary') : 'ri-expand-up-down-line text-muted' }} fs-12"></i>
+                        </th>
+                        <th :class="{'d-none': !cols[2]}" wire:click="sortBy('tdjkm.work_shift')" style="cursor:pointer;white-space:nowrap">
+                            Shift <i class="{{ $sortColumn === 'tdjkm.work_shift' ? ($sortDirection === 'asc' ? 'ri-arrow-up-s-line text-primary' : 'ri-arrow-down-s-line text-primary') : 'ri-expand-up-down-line text-muted' }} fs-12"></i>
+                        </th>
+                        <th :class="{'d-none': !cols[3]}" wire:click="sortBy('msm.machineno')" style="cursor:pointer;white-space:nowrap">
+                            Nomor Mesin <i class="{{ $sortColumn === 'msm.machineno' ? ($sortDirection === 'asc' ? 'ri-arrow-up-s-line text-primary' : 'ri-arrow-down-s-line text-primary') : 'ri-expand-up-down-line text-muted' }} fs-12"></i>
+                        </th>
+                        <th :class="{'d-none': !cols[4]}" wire:click="sortBy('mse.employeeno')" style="cursor:pointer;white-space:nowrap">
+                            NIK <i class="{{ $sortColumn === 'mse.employeeno' ? ($sortDirection === 'asc' ? 'ri-arrow-up-s-line text-primary' : 'ri-arrow-down-s-line text-primary') : 'ri-expand-up-down-line text-muted' }} fs-12"></i>
+                        </th>
+                        <th :class="{'d-none': !cols[5]}" wire:click="sortBy('mse.empname')" style="cursor:pointer;white-space:nowrap">
+                            Petugas <i class="{{ $sortColumn === 'mse.empname' ? ($sortDirection === 'asc' ? 'ri-arrow-up-s-line text-primary' : 'ri-arrow-down-s-line text-primary') : 'ri-expand-up-down-line text-muted' }} fs-12"></i>
+                        </th>
+                        <th :class="{'d-none': !cols[6]}" wire:click="sortBy('tdjkm.work_hour')" style="cursor:pointer;white-space:nowrap">
+                            Jam Kerja <i class="{{ $sortColumn === 'tdjkm.work_hour' ? ($sortDirection === 'asc' ? 'ri-arrow-up-s-line text-primary' : 'ri-arrow-down-s-line text-primary') : 'ri-expand-up-down-line text-muted' }} fs-12"></i>
+                        </th>
+                        <th :class="{'d-none': !cols[7]}" wire:click="sortBy('tdjkm.off_hour')" style="cursor:pointer;white-space:nowrap">
+                            Jam Mati <i class="{{ $sortColumn === 'tdjkm.off_hour' ? ($sortDirection === 'asc' ? 'ri-arrow-up-s-line text-primary' : 'ri-arrow-down-s-line text-primary') : 'ri-expand-up-down-line text-muted' }} fs-12"></i>
+                        </th>
+                        <th :class="{'d-none': !cols[8]}" wire:click="sortBy('tdjkm.on_hour')" style="cursor:pointer;white-space:nowrap">
+                            Jam Jalan <i class="{{ $sortColumn === 'tdjkm.on_hour' ? ($sortDirection === 'asc' ? 'ri-arrow-up-s-line text-primary' : 'ri-arrow-down-s-line text-primary') : 'ri-expand-up-down-line text-muted' }} fs-12"></i>
+                        </th>
+                        <th :class="{'d-none': !cols[9]}" style="white-space:nowrap">Update By</th>
+                        <th :class="{'d-none': !cols[10]}" wire:click="sortBy('tdjkm.updated_on')" style="cursor:pointer;white-space:nowrap">
+                            Updated <i class="{{ $sortColumn === 'tdjkm.updated_on' ? ($sortDirection === 'asc' ? 'ri-arrow-up-s-line text-primary' : 'ri-arrow-down-s-line text-primary') : 'ri-expand-up-down-line text-muted' }} fs-12"></i>
+                        </th>
+                        <th :class="{'d-none': !cols[11]}" wire:click="sortBy('tdjkm.created_on')" style="cursor:pointer;white-space:nowrap">
+                            Created <i class="{{ $sortColumn === 'tdjkm.created_on' ? ($sortDirection === 'asc' ? 'ri-arrow-up-s-line text-primary' : 'ri-arrow-down-s-line text-primary') : 'ri-expand-up-down-line text-muted' }} fs-12"></i>
+                        </th>
                     </tr>
-                @empty
-                @endforelse
-            </tbody>
-        </table>
+                </thead>
+                <tbody>
+                    @forelse ($data as $item)
+                        <tr>
+                            <td>
+                                <button type="button" class="btn fs-15 p-1 bg-primary rounded"
+                                    wire:click="edit({{ $item->id }})">
+                                    <i class="ri-edit-box-line text-white"></i>
+                                </button>
+                                <button type="button" class="btn fs-15 p-1 bg-danger rounded"
+                                    wire:click="delete({{ $item->id }})">
+                                    <i class="ri-delete-bin-line text-white"></i>
+                                </button>
+                            </td>
+                            <td :class="{'d-none': !cols[1]}">{{ \Carbon\Carbon::parse($item->working_date)->format('d M Y') }}</td>
+                            <td :class="{'d-none': !cols[2]}">{{ $item->work_shift }}</td>
+                            <td :class="{'d-none': !cols[3]}">{{ $item->machineno }}</td>
+                            <td :class="{'d-none': !cols[4]}">{{ $item->employeeno }}</td>
+                            <td :class="{'d-none': !cols[5]}">{{ $item->empname }}</td>
+                            <td :class="{'d-none': !cols[6]}">{{ $item->work_hour }}</td>
+                            <td :class="{'d-none': !cols[7]}">{{ $item->off_hour }}</td>
+                            <td :class="{'d-none': !cols[8]}">{{ $item->on_hour }}</td>
+                            <td :class="{'d-none': !cols[9]}">{{ $item->updated_by }}</td>
+                            <td :class="{'d-none': !cols[10]}">{{ \Carbon\Carbon::parse($item->updated_on)->format('d M Y H:i:s') }}</td>
+                            <td :class="{'d-none': !cols[11]}">{{ \Carbon\Carbon::parse($item->created_on)->format('d M Y H:i:s') }}</td>
+                        </tr>
+                    @empty
+                        <tr>
+                            <td colspan="12" class="text-center py-4">
+                                <lord-icon src="https://cdn.lordicon.com/msoeawqm.json" trigger="loop"
+                                    colors="primary:#121331,secondary:#08a88a" style="width:40px;height:40px"></lord-icon>
+                                <h5 class="mt-2">Record not Found..!</h5>
+                            </td>
+                        </tr>
+                    @endforelse
+                </tbody>
+            </table>
+        </div>
+
+        <div class="d-flex justify-content-between align-items-center flex-wrap mt-2 gap-2">
+            <div class="text-muted small">
+                @if ($data instanceof \Illuminate\Pagination\LengthAwarePaginator)
+                    Showing {{ $data->firstItem() ?? 0 }}–{{ $data->lastItem() ?? 0 }} of {{ $data->total() }} entries
+                @endif
+            </div>
+            <div>
+                @if ($data instanceof \Illuminate\Pagination\LengthAwarePaginator)
+                    {{ $data->links() }}
+                @endif
+            </div>
+        </div>
     </div>
 
     <style>
-        .modal-overlay-top {
-            z-index: 1060;
-            /* default Bootstrap modal z-index is 1055 */
-        }
-
+        .modal-overlay-top { z-index: 1060; }
         .modal-backdrop-custom {
-            position: fixed;
-            top: 0;
-            left: 0;
-            width: 100vw;
-            height: 100vh;
-            background-color: rgba(0, 0, 0, 0.5);
-            /* gelap transparan */
-            z-index: 1058;
-            /* di bawah modal-jam-mati, tapi di atas modal-jam-kerja */
+            position: fixed; top: 0; left: 0; width: 100vw; height: 100vh;
+            background-color: rgba(0,0,0,0.5); z-index: 1058;
         }
-
-        #seitaiTable.table>:not(caption)>*>* {
+        #seitaiTable.table > :not(caption) > * > * {
             font-size: 13px !important;
             padding: 4px 2px 4px 4px;
-            color: var(--tb-table-color-state, var(--tb-table-color-type, var(--tb-table-color)));
-            background-color: var(--tb-table-bg);
-            border-bottom-width: var(--tb-border-width);
-            box-shadow: inset 0 0 0 9999px var(--tb-table-bg-state, var(--tb-table-bg-type, var(--tb-table-accent-bg)));
         }
     </style>
+    @endif
 </div>
 
 @script
@@ -899,119 +879,38 @@
             $('#removModal').modal('hide');
         });
 
-        // datatable
-        // inisialisasi DataTable
-        $wire.on('initDataTable', () => {
-            initDataTable();
+        document.addEventListener('livewire:initialized', function() {
+            function initMachineSelect() {
+                if ($('.select2-machine-sjk').hasClass('select2-hidden-accessible')) {
+                    $('.select2-machine-sjk').select2('destroy');
+                }
+                $('.select2-machine-sjk').select2({
+                    theme: 'bootstrap-5', allowClear: true, placeholder: '- All -',
+                }).on('change', function() {
+                    @this.set('machine_id', $(this).val() || null);
+                });
+            }
+
+            function initShiftSelect() {
+                if ($('.select2-shift-sjk').hasClass('select2-hidden-accessible')) {
+                    $('.select2-shift-sjk').select2('destroy');
+                }
+                $('.select2-shift-sjk').select2({
+                    theme: 'bootstrap-5', allowClear: true, placeholder: '- All -',
+                }).on('change', function() {
+                    @this.set('work_shift_filter', $(this).val() || null);
+                });
+            }
+
+            initMachineSelect();
+            initShiftSelect();
+
+            Livewire.hook('morph', ({ el, component }) => {
+                setTimeout(() => {
+                    initMachineSelect();
+                    initShiftSelect();
+                }, 100);
+            });
         });
-
-        function calculateTableHeight() {
-            const totalHeight = window.innerHeight;
-
-            const filterSectionTop = document.querySelector('.filter-section')?.getBoundingClientRect().top || 0;
-            const offsetTop = document.querySelector('#seitaiTable')?.getBoundingClientRect().top || 0;
-
-            const paddingTop = document.querySelector('.navbar-header')?.getBoundingClientRect().top || 0;
-            const availableHeight = totalHeight - offsetTop - filterSectionTop - paddingTop;
-
-            return availableHeight;
-        }
-
-        // Fungsi untuk menginisialisasi ulang DataTable
-        function initDataTable() {
-            const savedOrder = $wire.get('sortingTable');
-
-            let defaultOrder = [
-                [1, "asc"]
-            ];
-            if (savedOrder) {
-                defaultOrder = savedOrder;
-            }
-            // Hapus DataTable jika sudah ada
-            if ($.fn.dataTable.isDataTable('#seitaiTable')) {
-                let table = $('#seitaiTable').DataTable();
-                table.clear(); // Bersihkan data tabel
-                table.destroy(); // Hancurkan DataTable
-            }
-
-            setTimeout(() => {
-                // Inisialisasi ulang DataTable
-                let table = $('#seitaiTable').DataTable({
-                    "pageLength": 10,
-                    "searching": true,
-                    "responsive": true,
-                    "scrollX": true,
-                    "order": defaultOrder,
-                    "scrollY": calculateTableHeight() + 'px',
-                    "scrollCollapse": true,
-                    "scrollX": true,
-                    "language": {
-                        "emptyTable": `
-                            <div class="text-center">
-                                <lord-icon src="https://cdn.lordicon.com/msoeawqm.json" trigger="loop"
-                                    colors="primary:#121331,secondary:#08a88a" style="width:40px;height:40px"></lord-icon>
-                                <h5 class="mt-2">Sorry! No Result Found</h5>
-                            </div>
-                        `
-                    }
-                });
-                // tombol edit
-                $('.btn-edit').on('click', function() {
-                    let id = $(this).attr('data-edit-id');
-
-                    // livewire click
-                    $wire.dispatch('edit', {
-                        id
-                    });
-                });
-                // tombol delete
-                $('.btn-delete').on('click', function() {
-                    let id = $(this).attr('data-delete-id');
-
-                    // livewire click
-                    $wire.dispatch('delete', {
-                        id
-                    });
-                });
-                // Listen to sort event
-                table.on('order.dt', function() {
-                    let order = table.order();
-                    if (order.length == 0 && defaultOrder.length > 0) {
-                        order = defaultOrder;
-                    }
-                    $wire.call('updateSortingTable', order);
-                });
-
-                // default column visibility
-                $('.toggle-column').each(function() {
-                    let column = table.column($(this).attr('data-column'));
-                    column.visible($(this).is(':checked'));
-                });
-
-                // Inisialisasi ulang event listener checkbox
-                $('.toggle-column').off('change').on('change', function() {
-                    let column = table.column($(this).attr('data-column'));
-                    column.visible(!column.visible());
-                });
-            }, 500);
-        }
     </script>
 @endscript
-
-<script>
-    document.addEventListener('livewire:load', function() {
-        // Listener untuk menampilkan modal
-        window.livewire.on('showModal', () => {
-            var modal = new bootstrap.Modal(document.getElementById('modal-add'));
-            modal.show();
-        });
-
-        // Listener untuk menutup modal
-        window.livewire.on('closeModal', () => {
-            var modal = bootstrap.Modal.getInstance(document.getElementById('modal-add'));
-            if (modal) {
-                modal.hide();
-            }
-        });
-    });
-</script>


### PR DESCRIPTION
## Ringkasan

Migrasi 2 halaman CRUD JamKerja (Infure & Seitai) dari DataTable.js client-side ke **server-side pagination + sorting**, mengikuti pola yang sama dengan PR #9 — sambil mempertahankan penuh semua fungsionalitas modal CRUD (Add/Edit/Delete/JamMatiMesin).

## Halaman yang dimigrasi

| Commit | Halaman |
|--------|---------|
| `fd3e9814` | Infure Jam Kerja + Seitai Jam Kerja |

## Perubahan Controller (berlaku untuk kedua halaman)

- **Lazy loading**: tambah `$isLoaded` + `loadData()` via `wire:init`
- **Server-side pagination**: `->paginate($perPage)` menggantikan `$this->data = $query->get()`
- **Server-side sorting**: `sortBy()` dengan whitelist 10 kolom + `#[Session] $sortColumn/$sortDirection`
- **Query ke render()**: hapus `getData()` public method, pindahkan query langsung ke `render()`
- **Cache master data**: `$machine` dan `$workShift` di-cache via `Cache::remember` (bukan public property lagi)
- **Normalisasi filter**: `$machine_id['value']` / `$work_shift_filter['value']` → plain scalar di `mount()`
- **Format tanggal**: `d-m-Y` → `Y-m-d` + regex guard
- **Hapus**: `rendered()` dispatch initDataTable, `updateSortingTable()`, `$sortingTable`, `$data = []`
- **Export filter**: pakai nilai scalar langsung setelah normalisasi

## Perubahan Blade (berlaku untuk kedua halaman)

- **Lazy loading skeleton** dengan animasi `ijk-bar-slide` / `sjk-bar-slide`
- **Date inputs**: flatpickr filter → `type="date"`, flatpickr Add modal → `type="date"` dengan `max`
- **Select2**: dropdown machine dan shift dari `data-choices` ke Select2 (class `-ijk` / `-sjk`)
- **Alpine.js column toggle**: menggantikan `toggle-column` DataTable JS (11 kolom, semua default visible)
- **Table**: sortable headers, `wire:loading` opacity state, pagination links + entry count
- **Script**: hapus `initDataTable` + `updateSortingTable`, tambah Select2 init + morph reinit
- **Hapus legacy**: block `<script>livewire:load</script>` Livewire v2 di seitai blade

## Catatan khusus

Halaman ini berbeda dari halaman list biasa — keduanya memiliki modal CRUD (Add/Edit/Delete/JamMatiMesin). Migrasi dilakukan dengan hati-hati:
- Semua `$this->getData()` calls di CRUD methods dihapus karena Livewire auto-re-render setelah setiap method call
- Modal content (±500 baris) tidak diubah sama sekali
- `$wire.on('showModal*', ...)` handlers dipertahankan di `@script`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
