### PR TITLE
Refactor report generation to stream download Excel files directly

### DIFF
--- a/app/Http/Livewire/JamKerja/CheckListJamKerjaController.php
+++ b/app/Http/Livewire/JamKerja/CheckListJamKerjaController.php
@@ -132,7 +132,13 @@ class CheckListJamKerjaController extends Component
 
         $response = $this->checklistJamKerja($tglAwal, $tglAkhir, $filter, $this->divisionId == 2 ? 'INFURE' : 'SEITAI', true);
         if ($response['status'] == 'success') {
-            return response()->download($response['filename'])->deleteFileAfterSend(true);
+            return response()->streamDownload(function () use ($response) {
+                // Langsung tembak ke output buffer browser
+                $response['writer']->save('php://output');
+            }, $response['filename'], [
+                'Content-Type' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+                'Cache-Control' => 'max-age=0',
+            ]);
         } else if ($response['status'] == 'error') {
             $this->dispatch('notification', ['type' => 'warning', 'message' => $response['message']]);
             return;
@@ -185,13 +191,12 @@ class CheckListJamKerjaController extends Component
         $spreadsheet->setActiveSheetIndex(0);
 
         $writer = new Xlsx($spreadsheet);
-        $filename = 'asset/report/JamKerja-' . $nippo . '.xlsx';
-        $writer->save($filename);
-        $response = [
-            'status' => 'success',
-            'filename' => $filename
+
+        return [
+            'status'   => 'success',
+            'writer'   => $writer,
+            'filename' => 'JamKerja-' . $nippo . '.xlsx'
         ];
-        return $response;
     }
 
     private function setupGeneralSheet($worksheet, $nippo, $filter, $tglAwal, $tglAkhir, $spreadsheet)

--- a/app/Http/Livewire/Kenpin/AddKenpinSeitaiController.php
+++ b/app/Http/Livewire/Kenpin/AddKenpinSeitaiController.php
@@ -655,8 +655,15 @@ class AddKenpinSeitaiController extends Component
         $this->save();
 
         $writer = new Xlsx($spreadsheet);
-        $writer->save('asset/report/KKSeitai-' . $this->kenpin_no . '.xlsx');
-        return response()->download('asset/report/KKSeitai-' . $this->kenpin_no . '.xlsx');
+        $filename = 'KKSeitai-' . $this->kenpin_no . '.xlsx';
+        return response()->streamDownload(function () use ($writer) {
+            // Data langsung ditembakkan ke buffer unduhan browser
+            $writer->save('php://output');
+        }, $filename, [
+            // Header spesifik untuk file Excel
+            'Content-Type' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+            'Cache-Control' => 'max-age=0',
+        ]);
     }
 
     public function cancel()

--- a/app/Http/Livewire/Kenpin/PrintLabelGudangKenpinController.php
+++ b/app/Http/Livewire/Kenpin/PrintLabelGudangKenpinController.php
@@ -524,8 +524,15 @@ class PrintLabelGudangKenpinController extends Component
         }
 
         $writer = new Xlsx($spreadsheet);
-        $writer->save('asset/report/Label-Gudang-' . $this->nomor_palet . '.xlsx');
-        return response()->download('asset/report/Label-Gudang-' . $this->nomor_palet . '.xlsx')->deleteFileAfterSend(true);
+        $filename = 'Label-Gudang-' . $this->nomor_palet . '.xlsx';
+        return response()->streamDownload(function () use ($writer) {
+            // Data langsung ditembakkan ke buffer unduhan browser
+            $writer->save('php://output');
+        }, $filename, [
+            // Header spesifik untuk file Excel
+            'Content-Type' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+            'Cache-Control' => 'max-age=0',
+        ]);
     }
 
     public function render()

--- a/app/Http/Livewire/NippoSeitai/CheckListSeitaiController.php
+++ b/app/Http/Livewire/NippoSeitai/CheckListSeitaiController.php
@@ -75,7 +75,13 @@ class CheckListSeitaiController extends Component
         if ($this->jenisReport == 'CheckList') {
             $response = $this->checklist();
             if ($response['status'] == 'success') {
-                return response()->download($response['filename'])->deleteFileAfterSend(true);
+                return response()->streamDownload(function () use ($response) {
+                    // Langsung tembak ke output buffer browser
+                    $response['writer']->save('php://output');
+                }, $response['filename'], [
+                    'Content-Type' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+                    'Cache-Control' => 'max-age=0',
+                ]);
             } else if ($response['status'] == 'error') {
                 $this->dispatch('notification', ['type' => 'warning', 'message' => $response['message']]);
                 return;
@@ -83,7 +89,13 @@ class CheckListSeitaiController extends Component
         } else if ($this->jenisReport == 'LossSeitai') {
             $response = $this->loss();
             if ($response['status'] == 'success') {
-                return response()->download($response['filename'])->deleteFileAfterSend(true);
+                return response()->streamDownload(function () use ($response) {
+                    // Langsung tembak ke output buffer browser
+                    $response['writer']->save('php://output');
+                }, $response['filename'], [
+                    'Content-Type' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+                    'Cache-Control' => 'max-age=0',
+                ]);
             } else if ($response['status'] == 'error') {
                 $this->dispatch('notification', ['type' => 'warning', 'message' => $response['message']]);
                 return;
@@ -643,13 +655,12 @@ class CheckListSeitaiController extends Component
         $spreadsheet->getActiveSheet()->getColumnDimension('L')->setWidth(8.2);
 
         $writer = new Xlsx($spreadsheet);
-        $filename = 'asset/report/NippoSeitai-' . $this->jenisReport . '.xlsx';
-        $writer->save($filename);
-        $response = [
-            'status' => 'success',
-            'filename' => $filename
+
+        return [
+            'status'   => 'success',
+            'writer'   => $writer,
+            'filename' => 'NippoSeitai-' . $this->jenisReport . '.xlsx'
         ];
-        return $response;
     }
 
     public function loss()
@@ -973,9 +984,7 @@ class CheckListSeitaiController extends Component
                 phpspreadsheet::textAlignCenter($spreadsheet, $columnPetugas . $rowItemStart);
                 // Petugas
                 $activeWorksheet->setCellValue($columnPetugas . $rowItemEnd, $item['namapetugas']);
-                // $spreadsheet->getActiveSheet()->mergeCells($columnPetugas . $rowItemEnd . ':' . $columnLpk . $rowItemEnd);
                 phpspreadsheet::styleFont($spreadsheet, $columnPetugas . $rowItemEnd, false, 8, 'Calibri');
-                // phpspreadsheet::textAlignCenter($spreadsheet, $columnPetugas . $rowItemEnd);
 
                 // border
                 phpspreadsheet::addFullBorder($spreadsheet, $startColumn . $rowItemStart . ':' . $columnPetugas . $rowItemEnd);
@@ -1026,7 +1035,6 @@ class CheckListSeitaiController extends Component
         }
         $activeWorksheet->setCellValue($columnBerat . $rowGrandTotal, $totalBeratLoss);
         phpspreadsheet::addFullBorder($spreadsheet, 'A' . $rowGrandTotal . ':' . $columnBerat . $rowGrandTotal);
-        // phpSpreadsheet::numberFormatCommaThousandsOrZero($spreadsheet, $columnQty . $rowGrandTotal);
 
         phpspreadsheet::styleFont($spreadsheet, 'A' . $rowGrandTotal . ':' . $columnBerat . $rowGrandTotal, true, 9, 'Calibri');
 
@@ -1038,18 +1046,15 @@ class CheckListSeitaiController extends Component
         $spreadsheet->getActiveSheet()->getColumnDimension('E')->setWidth(12.0);
         $spreadsheet->getActiveSheet()->getColumnDimension('F')->setWidth(15.0);
         $spreadsheet->getActiveSheet()->getColumnDimension('G')->setWidth(25.0);
-        // $activeWorksheet->getStyle('G' . $rowHeaderStart)->getAlignment()->setWrapText(true);
         $spreadsheet->getActiveSheet()->getColumnDimension('H')->setWidth(10.5);
         $spreadsheet->getActiveSheet()->getColumnDimension('I')->setWidth(12.0);
 
         $writer = new Xlsx($spreadsheet);
-        $filename = 'NippoSeitai-' . $this->jenisReport . '.xlsx';
-        $writer->save($filename);
-        $response = [
-            'status' => 'success',
-            'filename' => $filename
+        return [
+            'status'   => 'success',
+            'writer'   => $writer,
+            'filename' => 'NippoSeitai-' . $this->jenisReport . '.xlsx' // Hanya nama file untuk trigger browser
         ];
-        return $response;
     }
 
     public static function dataProduksi($orderId)
@@ -1293,17 +1298,6 @@ class CheckListSeitaiController extends Component
         for ($col = 'A'; $col <= 'W'; $col++) {
             $activeWorksheet->getColumnDimension($col)->setWidth(3.5);
         }
-
-        // Row heights
-        // for ($row = 1; $row <= 17; $row++) {
-        //     $activeWorksheet->getRowDimension($row)->setRowHeight(25);
-        // }
-
-        // // Special row heights
-        // $activeWorksheet->getRowDimension(11)->setRowHeight(40);
-        // $activeWorksheet->getRowDimension(12)->setRowHeight(40);
-        // $activeWorksheet->getRowDimension(13)->setRowHeight(40);
-        // $activeWorksheet->getRowDimension(14)->setRowHeight(40);
 
         // Save file
         $writer = new Xlsx($spreadsheet);

--- a/app/Http/Livewire/NippoSeitai/LabelMasukGudangController.php
+++ b/app/Http/Livewire/NippoSeitai/LabelMasukGudangController.php
@@ -622,8 +622,16 @@ class LabelMasukGudangController extends Component
         ]);
 
         $writer = new Xlsx($spreadsheet);
-        $writer->save('asset/report/Label-Gudang-' . $this->nomor_palet . '.xlsx');
-        return response()->download('asset/report/Label-Gudang-' . $this->nomor_palet . '.xlsx')->deleteFileAfterSend(true);
+
+        $filename = 'Label-Gudang-' . $this->nomor_palet . '.xlsx';
+        return response()->streamDownload(function () use ($writer) {
+            // Data langsung ditembakkan ke buffer unduhan browser
+            $writer->save('php://output');
+        }, $filename, [
+            // Header spesifik untuk file Excel
+            'Content-Type' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+            'Cache-Control' => 'max-age=0',
+        ]);
     }
 
     public function render()

--- a/app/Http/Livewire/NippoSeitai/LossSeitaiController.php
+++ b/app/Http/Livewire/NippoSeitai/LossSeitaiController.php
@@ -554,8 +554,16 @@ class LossSeitaiController extends Component
         // $spreadsheet->getActiveSheet()->getColumnDimension($columnMesin)->setWidth(72, 'px');
 
         $writer = new Xlsx($spreadsheet);
-        $writer->save('asset/report/LossSeitai-Checklist.xlsx');
-        return response()->download('asset/report/LossSeitai-Checklist.xlsx');
+
+        $filename = 'LossSeitai-Checklist.xlsx';
+        return response()->streamDownload(function () use ($writer) {
+            // Data langsung ditembakkan ke buffer unduhan browser
+            $writer->save('php://output');
+        }, $filename, [
+            // Header spesifik untuk file Excel
+            'Content-Type' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+            'Cache-Control' => 'max-age=0',
+        ]);
     }
 
     public function render()

--- a/app/Http/Livewire/Report/GeneralReport/JamMatiReportService.php
+++ b/app/Http/Livewire/Report/GeneralReport/JamMatiReportService.php
@@ -180,13 +180,13 @@ class JamMatiReportService
         }
 
         $writer = new Xlsx($spreadsheet);
-        $filename = 'asset/report/' . $nipon . '-' . $jenisReport . '.xlsx';
-        $writer->save($filename);
-        $response = [
-            'status' => 'success',
+        $filename = $nipon . '-' . $jenisReport . '.xlsx';
+
+        return [
+            'status'   => 'success',
+            'writer'   => $writer,
             'filename' => $filename
         ];
-        return $response;
     }
 
     public static function jamMatiPerJenis($nipon, $jenisReport, $tglMasuk, $tglKeluar)
@@ -538,12 +538,12 @@ class JamMatiReportService
             ->setWrapText(true);
 
         $writer = new Xlsx($spreadsheet);
-        $filename = 'asset/report/' . $nipon . '-' . $jenisReport . '.xlsx';
-        $writer->save($filename);
-        $response = [
-            'status' => 'success',
+        $filename = $nipon . '-' . $jenisReport . '.xlsx';
+
+        return [
+            'status'   => 'success',
+            'writer'   => $writer,
             'filename' => $filename
         ];
-        return $response;
     }
 }

--- a/app/Http/Livewire/Report/GeneralReport/KapasitasProduksiReportService.php
+++ b/app/Http/Livewire/Report/GeneralReport/KapasitasProduksiReportService.php
@@ -357,13 +357,12 @@ class KapasitasProduksiReportService
         $spreadsheet->getActiveSheet()->getColumnDimension('I')->setAutoSize(true);
 
         $writer = new Xlsx($spreadsheet);
-        $filename = 'asset/report/' . $nippon . '-' . $jenisReport . '.xlsx';
-        $writer->save($filename);
-        $response = [
-            'status' => 'success',
+        $filename = $nippon . '-' . $jenisReport . '.xlsx';
+        return [
+            'status'   => 'success',
+            'writer'   => $writer,
             'filename' => $filename
         ];
-        return $response;
     }
 
     public static function kapasitasProduksiSeitai($nippon, $jenisReport, $tglMasuk, $tglKeluar)
@@ -711,12 +710,12 @@ class KapasitasProduksiReportService
         $spreadsheet->getActiveSheet()->getColumnDimension('I')->setAutoSize(true);
 
         $writer = new Xlsx($spreadsheet);
-        $filename = 'asset/report/' . $nippon . '-' . $jenisReport . '.xlsx';
-        $writer->save($filename);
-        $response = [
-            'status' => 'success',
+        $filename = $nippon . '-' . $jenisReport . '.xlsx';
+
+        return [
+            'status'   => 'success',
+            'writer'   => $writer,
             'filename' => $filename
         ];
-        return $response;
     }
 }

--- a/app/Http/Livewire/Report/GeneralReport/LossKasusReportService.php
+++ b/app/Http/Livewire/Report/GeneralReport/LossKasusReportService.php
@@ -365,13 +365,13 @@ class LossKasusReportService
         $spreadsheet->getActiveSheet()->getColumnDimension('B')->setAutoSize(true);
 
         $writer = new Xlsx($spreadsheet);
-        $filename = 'asset/report/' . $nipon . '-' . $jenisReport . '.xlsx';
-        $writer->save($filename);
-        $response = [
-            'status' => 'success',
+        $filename = $nipon . '-' . $jenisReport . '.xlsx';
+
+        return [
+            'status'   => 'success',
+            'writer'   => $writer,
             'filename' => $filename
         ];
-        return $response;
     }
 
     public static function daftarKasusLossPerMesinJenis($nipon, $jenisReport, $tglMasuk, $tglKeluar)
@@ -726,12 +726,12 @@ class LossKasusReportService
         $spreadsheet->getActiveSheet()->getColumnDimension('B')->setAutoSize(true);
 
         $writer = new Xlsx($spreadsheet);
-        $filename = 'asset/report/' . $nipon . '-' . $jenisReport . '.xlsx';
-        $writer->save($filename);
-        $response = [
-            'status' => 'success',
+        $filename = $nipon . '-' . $jenisReport . '.xlsx';
+
+        return [
+            'status'   => 'success',
+            'writer'   => $writer,
             'filename' => $filename
         ];
-        return $response;
     }
 }

--- a/app/Http/Livewire/Report/GeneralReport/LossPerDepartemenPerJenisReportService.php
+++ b/app/Http/Livewire/Report/GeneralReport/LossPerDepartemenPerJenisReportService.php
@@ -322,13 +322,12 @@ class LossPerDepartemenPerJenisReportService
         }
 
         $writer = new Xlsx($spreadsheet);
-        $filename = 'asset/report/' . $nippon . '-' . $jenisReport . '.xlsx';
-        $writer->save($filename);
-        $response = [
-            'status' => 'success',
+        $filename = $nippon . '-' . $jenisReport . '.xlsx';
+        return [
+            'status'   => 'success',
+            'writer'   => $writer,
             'filename' => $filename
         ];
-        return $response;
     }
 
     public static function daftarLossPerDepartemenPerJenisSeitai($nippon, $jenisReport, $tglMasuk, $tglKeluar)
@@ -642,12 +641,11 @@ class LossPerDepartemenPerJenisReportService
         }
 
         $writer = new Xlsx($spreadsheet);
-        $filename = 'asset/report/' . $nippon . '-' . $jenisReport . '.xlsx';
-        $writer->save($filename);
-        $response = [
-            'status' => 'success',
+        $filename = $nippon . '-' . $jenisReport . '.xlsx';
+        return [
+            'status'   => 'success',
+            'writer'   => $writer,
             'filename' => $filename
         ];
-        return $response;
     }
 }

--- a/app/Http/Livewire/Report/GeneralReport/LossPerDepartemenReportService.php
+++ b/app/Http/Livewire/Report/GeneralReport/LossPerDepartemenReportService.php
@@ -300,13 +300,12 @@ class LossPerDepartemenReportService
         }
 
         $writer = new Xlsx($spreadsheet);
-        $filename = 'asset/report/' . $nippon . '-' . $jenisReport . '.xlsx';
-        $writer->save($filename);
-        $response = [
-            'status' => 'success',
+        $filename = $nippon . '-' . $jenisReport . '.xlsx';
+        return [
+            'status'   => 'success',
+            'writer'   => $writer,
             'filename' => $filename
         ];
-        return $response;
     }
 
     public static function daftarLossPerDepartemenSeitai($nippon, $jenisReport, $tglMasuk, $tglKeluar)
@@ -597,7 +596,7 @@ class LossPerDepartemenReportService
         }
 
         $writer = new Xlsx($spreadsheet);
-        $filename = 'asset/report/' . $nippon . '-' . $jenisReport . '.xlsx';
+        $filename = $nippon . '-' . $jenisReport . '.xlsx';
         $writer->save($filename);
         $response = [
             'status' => 'success',

--- a/app/Http/Livewire/Report/GeneralReport/LossPerMesinReportService.php
+++ b/app/Http/Livewire/Report/GeneralReport/LossPerMesinReportService.php
@@ -301,13 +301,12 @@ class LossPerMesinReportService
         }
 
         $writer = new Xlsx($spreadsheet);
-        $filename = 'asset/report/' . $nippon . '-' . $jenisReport . '.xlsx';
-        $writer->save($filename);
-        $response = [
-            'status' => 'success',
+        $filename = $nippon . '-' . $jenisReport . '.xlsx';
+        return [
+            'status'   => 'success',
+            'writer'   => $writer,
             'filename' => $filename
         ];
-        return $response;
     }
 
     public static function daftarLossPerMesinSeitai($nippon, $jenisReport, $tglMasuk, $tglKeluar)
@@ -601,12 +600,12 @@ class LossPerMesinReportService
         }
 
         $writer = new Xlsx($spreadsheet);
-        $filename = 'asset/report/' . $nippon . '-' . $jenisReport . '.xlsx';
-        $writer->save($filename);
-        $response = [
-            'status' => 'success',
+        $filename = $nippon . '-' . $jenisReport . '.xlsx';
+
+        return [
+            'status'   => 'success',
+            'writer'   => $writer,
             'filename' => $filename
         ];
-        return $response;
     }
 }

--- a/app/Http/Livewire/Report/GeneralReport/LossPerPetugasReportService.php
+++ b/app/Http/Livewire/Report/GeneralReport/LossPerPetugasReportService.php
@@ -528,13 +528,12 @@ class LossPerPetugasReportService
         }
 
         $writer = new Xlsx($spreadsheet);
-        $filename = 'asset/report/' . $nippon . '-' . $jenisReport . '.xlsx';
-        $writer->save($filename);
-        $response = [
-            'status' => 'success',
+        $filename = $nippon . '-' . $jenisReport . '.xlsx';
+        return [
+            'status'   => 'success',
+            'writer'   => $writer,
             'filename' => $filename
         ];
-        return $response;
     }
 
     public static function daftarLossPerPetugasSeitai($nippon, $jenisReport, $tglMasuk, $tglKeluar)
@@ -942,12 +941,12 @@ class LossPerPetugasReportService
         }
 
         $writer = new Xlsx($spreadsheet);
-        $filename = 'asset/report/' . $nippon . '-' . $jenisReport . '.xlsx';
-        $writer->save($filename);
-        $response = [
-            'status' => 'success',
+        $filename = $nippon . '-' . $jenisReport . '.xlsx';
+
+        return [
+            'status'   => 'success',
+            'writer'   => $writer,
             'filename' => $filename
         ];
-        return $response;
     }
 }

--- a/app/Http/Livewire/Report/GeneralReport/ProduksiPerDepartemenPerJenisReportService.php
+++ b/app/Http/Livewire/Report/GeneralReport/ProduksiPerDepartemenPerJenisReportService.php
@@ -363,13 +363,12 @@ class ProduksiPerDepartemenPerJenisReportService
         }
 
         $writer = new Xlsx($spreadsheet);
-        $filename = 'asset/report/' . $nippon . '-' . $jenisReport . '.xlsx';
-        $writer->save($filename);
-        $response = [
-            'status' => 'success',
+        $filename = $nippon . '-' . $jenisReport . '.xlsx';
+        return [
+            'status'   => 'success',
+            'writer'   => $writer,
             'filename' => $filename
         ];
-        return $response;
     }
 
     public static function daftarProduksiPerDepartemenPerJenisSeitai($nippon, $jenisReport, $tglMasuk, $tglKeluar)
@@ -706,12 +705,11 @@ class ProduksiPerDepartemenPerJenisReportService
         }
 
         $writer = new Xlsx($spreadsheet);
-        $filename = 'asset/report/' . $nippon . '-' . $jenisReport . '.xlsx';
-        $writer->save($filename);
-        $response = [
-            'status' => 'success',
+        $filename = $nippon . '-' . $jenisReport . '.xlsx';
+        return [
+            'status'   => 'success',
+            'writer'   => $writer,
             'filename' => $filename
         ];
-        return $response;
     }
 }

--- a/app/Http/Livewire/Report/GeneralReport/ProduksiPerDepartemenPerPetugasReportService.php
+++ b/app/Http/Livewire/Report/GeneralReport/ProduksiPerDepartemenPerPetugasReportService.php
@@ -361,13 +361,12 @@ class ProduksiPerDepartemenPerPetugasReportService
         }
 
         $writer = new Xlsx($spreadsheet);
-        $filename = 'asset/report/' . $nippon . '-' . $jenisReport . '.xlsx';
-        $writer->save($filename);
-        $response = [
-            'status' => 'success',
+        $filename = $nippon . '-' . $jenisReport . '.xlsx';
+        return [
+            'status'   => 'success',
+            'writer'   => $writer,
             'filename' => $filename
         ];
-        return $response;
     }
 
     public static function daftarProduksiPerDepartemenPerPetugasSeitai($nippon, $jenisReport, $tglMasuk, $tglKeluar)
@@ -698,12 +697,11 @@ class ProduksiPerDepartemenPerPetugasReportService
         }
 
         $writer = new Xlsx($spreadsheet);
-        $filename = 'asset/report/' . $nippon . '-' . $jenisReport . '.xlsx';
-        $writer->save($filename);
-        $response = [
-            'status' => 'success',
+        $filename = $nippon . '-' . $jenisReport . '.xlsx';
+        return [
+            'status'   => 'success',
+            'writer'   => $writer,
             'filename' => $filename
         ];
-        return $response;
     }
 }

--- a/app/Http/Livewire/Report/GeneralReport/ProduksiPerDepartemenPerTypeReportService.php
+++ b/app/Http/Livewire/Report/GeneralReport/ProduksiPerDepartemenPerTypeReportService.php
@@ -365,13 +365,12 @@ class ProduksiPerDepartemenPerTypeReportService
             $col++;
         }
         $writer = new Xlsx($spreadsheet);
-        $filename = 'asset/report/' . $nippon . '-' . $jenisReport . '.xlsx';
-        $writer->save($filename);
-        $response = [
-            'status' => 'success',
+        $filename = $nippon . '-' . $jenisReport . '.xlsx';
+        return [
+            'status'   => 'success',
+            'writer'   => $writer,
             'filename' => $filename
         ];
-        return $response;
     }
 
     public static function daftarProduksiPerDepartemenPerTypeSeitai($nippon, $jenisReport, $tglMasuk, $tglKeluar)
@@ -707,12 +706,11 @@ class ProduksiPerDepartemenPerTypeReportService
         }
 
         $writer = new Xlsx($spreadsheet);
-        $filename = 'asset/report/' . $nippon . '-' . $jenisReport . '.xlsx';
-        $writer->save($filename);
-        $response = [
-            'status' => 'success',
+        $filename = $nippon . '-' . $jenisReport . '.xlsx';
+        return [
+            'status'   => 'success',
+            'writer'   => $writer,
             'filename' => $filename
         ];
-        return $response;
     }
 }

--- a/app/Http/Livewire/Report/GeneralReport/ProduksiPerJenisReportService.php
+++ b/app/Http/Livewire/Report/GeneralReport/ProduksiPerJenisReportService.php
@@ -316,13 +316,12 @@ class ProduksiPerJenisReportService
         }
 
         $writer = new Xlsx($spreadsheet);
-        $filename = 'asset/report/' . $nippon . '-' . $jenisReport . '.xlsx';
-        $writer->save($filename);
-        $response = [
-            'status' => 'success',
+        $filename = $nippon . '-' . $jenisReport . '.xlsx';
+        return [
+            'status'   => 'success',
+            'writer'   => $writer,
             'filename' => $filename
         ];
-        return $response;
     }
 
     public static function daftarProduksiPerJenisSeitai($nippon, $jenisReport, $tglMasuk, $tglKeluar)
@@ -601,12 +600,11 @@ class ProduksiPerJenisReportService
         }
 
         $writer = new Xlsx($spreadsheet);
-        $filename = 'asset/report/' . $nippon . '-' . $jenisReport . '.xlsx';
-        $writer->save($filename);
-        $response = [
-            'status' => 'success',
+        $filename = $nippon . '-' . $jenisReport . '.xlsx';
+        return [
+            'status'   => 'success',
+            'writer'   => $writer,
             'filename' => $filename
         ];
-        return $response;
     }
 }

--- a/app/Http/Livewire/Report/GeneralReport/ProduksiPerMesinPerProdukReportService.php
+++ b/app/Http/Livewire/Report/GeneralReport/ProduksiPerMesinPerProdukReportService.php
@@ -414,13 +414,12 @@ class ProduksiPerMesinPerProdukReportService
         }
 
         $writer = new Xlsx($spreadsheet);
-        $filename = 'asset/report/' . $nippon . '-' . $jenisReport . '.xlsx';
-        $writer->save($filename);
-        $response = [
-            'status' => 'success',
+        $filename = $nippon . '-' . $jenisReport . '.xlsx';
+        return [
+            'status'   => 'success',
+            'writer'   => $writer,
             'filename' => $filename
         ];
-        return $response;
     }
 
     public static function daftarProduksiPerMesinPerProdukSeitai($nippon, $jenisReport, $tglMasuk, $tglKeluar)
@@ -787,12 +786,12 @@ class ProduksiPerMesinPerProdukReportService
         }
 
         $writer = new Xlsx($spreadsheet);
-        $filename = 'asset/report/' . $nippon . '-' . $jenisReport . '.xlsx';
-        $writer->save($filename);
-        $response = [
-            'status' => 'success',
+        $filename = $nippon . '-' . $jenisReport . '.xlsx';
+
+        return [
+            'status'   => 'success',
+            'writer'   => $writer,
             'filename' => $filename
         ];
-        return $response;
     }
 }

--- a/app/Http/Livewire/Report/GeneralReport/ProduksiPerMesinReportService.php
+++ b/app/Http/Livewire/Report/GeneralReport/ProduksiPerMesinReportService.php
@@ -480,13 +480,12 @@ class ProduksiPerMesinReportService
         $spreadsheet->getActiveSheet()->getColumnDimension($columnMesinEnd)->setAutoSize(true);
 
         $writer = new Xlsx($spreadsheet);
-        $filename = 'asset/report/' . $nippon . '-' . $jenisReport . '.xlsx';
-        $writer->save($filename);
-        $response = [
-            'status' => 'success',
+        $filename = $nippon . '-' . $jenisReport . '.xlsx';
+        return [
+            'status'   => 'success',
+            'writer'   => $writer,
             'filename' => $filename
         ];
-        return $response;
     }
 
     public static function daftarProduksiPerMesinSeitai($nippon, $jenisReport, $tglMasuk, $tglKeluar)
@@ -923,12 +922,12 @@ class ProduksiPerMesinReportService
         $spreadsheet->getActiveSheet()->getColumnDimension('C')->setAutoSize(true);
 
         $writer = new Xlsx($spreadsheet);
-        $filename = 'asset/report/' . $nippon . '-' . $jenisReport . '.xlsx';
-        $writer->save($filename);
-        $response = [
-            'status' => 'success',
+        $filename = $nippon . '-' . $jenisReport . '.xlsx';
+
+        return [
+            'status'   => 'success',
+            'writer'   => $writer,
             'filename' => $filename
         ];
-        return $response;
     }
 }

--- a/app/Http/Livewire/Report/GeneralReport/ProduksiPerProdukReportService.php
+++ b/app/Http/Livewire/Report/GeneralReport/ProduksiPerProdukReportService.php
@@ -304,13 +304,12 @@ class ProduksiPerProdukReportService
         }
 
         $writer = new Xlsx($spreadsheet);
-        $filename = 'asset/report/' . $nippon . '-' . $jenisReport . '.xlsx';
-        $writer->save($filename);
-        $response = [
-            'status' => 'success',
+        $filename = $nippon . '-' . $jenisReport . '.xlsx';
+        return [
+            'status'   => 'success',
+            'writer'   => $writer,
             'filename' => $filename
         ];
-        return $response;
     }
 
     public static function daftarProduksiPerProdukSeitai($nippon, $jenisReport, $tglMasuk, $tglKeluar)
@@ -584,12 +583,11 @@ class ProduksiPerProdukReportService
         }
 
         $writer = new Xlsx($spreadsheet);
-        $filename = 'asset/report/' . $nippon . '-' . $jenisReport . '.xlsx';
-        $writer->save($filename);
-        $response = [
-            'status' => 'success',
+        $filename = $nippon . '-' . $jenisReport . '.xlsx';
+        return [
+            'status'   => 'success',
+            'writer'   => $writer,
             'filename' => $filename
         ];
-        return $response;
     }
 }

--- a/app/Http/Livewire/Report/GeneralReport/ProduksiPerTypePerMesinReportService.php
+++ b/app/Http/Livewire/Report/GeneralReport/ProduksiPerTypePerMesinReportService.php
@@ -451,13 +451,12 @@ class ProduksiPerTypePerMesinReportService
         $activeWorksheet->getStyle($columnTipeProduk . $rowHeaderStart . ':' . $columnHeaderEnd . $rowHeaderStart)->getAlignment()->setWrapText(true);
 
         $writer = new Xlsx($spreadsheet);
-        $filename = 'asset/report/' . $nippon . '-' . $jenisReport . '.xlsx';
-        $writer->save($filename);
-        $response = [
-            'status' => 'success',
+        $filename = $nippon . '-' . $jenisReport . '.xlsx';
+        return [
+            'status'   => 'success',
+            'writer'   => $writer,
             'filename' => $filename
         ];
-        return $response;
     }
 
     public static function daftarProduksiPerTipePerMesinSeitai($nippon, $jenisReport, $tglMasuk, $tglKeluar)
@@ -847,12 +846,12 @@ class ProduksiPerTypePerMesinReportService
         $activeWorksheet->getStyle($columnTipeProduk . $rowHeaderStart . ':' . $columnHeaderEnd . $rowHeaderStart)->getAlignment()->setWrapText(true);
 
         $writer = new Xlsx($spreadsheet);
-        $filename = 'asset/report/' . $nippon . '-' . $jenisReport . '.xlsx';
-        $writer->save($filename);
-        $response = [
-            'status' => 'success',
+        $filename = $nippon . '-' . $jenisReport . '.xlsx';
+
+        return [
+            'status'   => 'success',
+            'writer'   => $writer,
             'filename' => $filename
         ];
-        return $response;
     }
 }

--- a/app/Http/Livewire/Report/GeneralReport/ProduksiPerTypeReportService.php
+++ b/app/Http/Livewire/Report/GeneralReport/ProduksiPerTypeReportService.php
@@ -297,13 +297,12 @@ class ProduksiPerTypeReportService
         $spreadsheet->getActiveSheet()->getColumnDimension('C')->setAutoSize(true); // Type name
 
         $writer = new Xlsx($spreadsheet);
-        $filename = 'asset/report/' . $nippon . '-' . $jenisReport . '.xlsx';
-        $writer->save($filename);
-        $response = [
-            'status' => 'success',
+        $filename = $nippon . '-' . $jenisReport . '.xlsx';
+        return [
+            'status'   => 'success',
+            'writer'   => $writer,
             'filename' => $filename
         ];
-        return $response;
     }
 
     public static function daftarProduksiPerTipeSeitai($nippon, $jenisReport, $tglMasuk, $tglKeluar)
@@ -561,12 +560,11 @@ class ProduksiPerTypeReportService
         }
 
         $writer = new Xlsx($spreadsheet);
-        $filename = 'asset/report/' . $nippon . '-' . $jenisReport . '.xlsx';
-        $writer->save($filename);
-        $response = [
-            'status' => 'success',
+        $filename = $nippon . '-' . $jenisReport . '.xlsx';
+        return [
+            'status'   => 'success',
+            'writer'   => $writer,
             'filename' => $filename
         ];
-        return $response;
     }
 }

--- a/app/Http/Livewire/Report/GeneralReportController.php
+++ b/app/Http/Livewire/Report/GeneralReportController.php
@@ -73,7 +73,13 @@ class GeneralReportController extends Component
                 if ($this->nipon == 'Infure') {
                     $response = $this->daftarProduksiPerMesinInfure($tglMasuk, $tglKeluar);
                     if ($response['status'] == 'success') {
-                        return response()->download($response['filename'])->deleteFileAfterSend(true);
+                        return response()->streamDownload(function () use ($response) {
+                            // Langsung tembak ke output buffer browser
+                            $response['writer']->save('php://output');
+                        }, $response['filename'], [
+                            'Content-Type' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+                            'Cache-Control' => 'max-age=0',
+                        ]);
                     } else if ($response['status'] == 'error') {
                         $this->dispatch('notification', ['type' => 'warning', 'message' => $response['message']]);
                         return;
@@ -81,7 +87,13 @@ class GeneralReportController extends Component
                 } else {
                     $response = $this->daftarProduksiPerMesinSeitai($tglMasuk, $tglKeluar);
                     if ($response['status'] == 'success') {
-                        return response()->download($response['filename'])->deleteFileAfterSend(true);
+                        return response()->streamDownload(function () use ($response) {
+                            // Langsung tembak ke output buffer browser
+                            $response['writer']->save('php://output');
+                        }, $response['filename'], [
+                            'Content-Type' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+                            'Cache-Control' => 'max-age=0',
+                        ]);
                     } else if ($response['status'] == 'error') {
                         $this->dispatch('notification', ['type' => 'warning', 'message' => $response['message']]);
                         return;
@@ -92,7 +104,13 @@ class GeneralReportController extends Component
                 if ($this->nipon == 'Infure') {
                     $response = $this->daftarProduksiPerTipePerMesinInfure($tglMasuk, $tglKeluar);
                     if ($response['status'] == 'success') {
-                        return response()->download($response['filename'])->deleteFileAfterSend(true);
+                        return response()->streamDownload(function () use ($response) {
+                            // Langsung tembak ke output buffer browser
+                            $response['writer']->save('php://output');
+                        }, $response['filename'], [
+                            'Content-Type' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+                            'Cache-Control' => 'max-age=0',
+                        ]);
                     } else if ($response['status'] == 'error') {
                         $this->dispatch('notification', ['type' => 'warning', 'message' => $response['message']]);
                         return;
@@ -100,7 +118,13 @@ class GeneralReportController extends Component
                 } else {
                     $response = $this->daftarProduksiPerTipePerMesinSeitai($tglMasuk, $tglKeluar);
                     if ($response['status'] == 'success') {
-                        return response()->download($response['filename'])->deleteFileAfterSend(true);
+                        return response()->streamDownload(function () use ($response) {
+                            // Langsung tembak ke output buffer browser
+                            $response['writer']->save('php://output');
+                        }, $response['filename'], [
+                            'Content-Type' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+                            'Cache-Control' => 'max-age=0',
+                        ]);
                     } else if ($response['status'] == 'error') {
                         $this->dispatch('notification', ['type' => 'warning', 'message' => $response['message']]);
                         return;
@@ -111,7 +135,13 @@ class GeneralReportController extends Component
                 if ($this->nipon == 'Infure') {
                     $response = $this->daftarProduksiPerJenisInfure($tglMasuk, $tglKeluar);
                     if ($response['status'] == 'success') {
-                        return response()->download($response['filename'])->deleteFileAfterSend(true);
+                        return response()->streamDownload(function () use ($response) {
+                            // Langsung tembak ke output buffer browser
+                            $response['writer']->save('php://output');
+                        }, $response['filename'], [
+                            'Content-Type' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+                            'Cache-Control' => 'max-age=0',
+                        ]);
                     } else if ($response['status'] == 'error') {
                         $this->dispatch('notification', ['type' => 'warning', 'message' => $response['message']]);
                         return;
@@ -119,7 +149,13 @@ class GeneralReportController extends Component
                 } else {
                     $response = $this->daftarProduksiPerJenisSeitai($tglMasuk, $tglKeluar);
                     if ($response['status'] == 'success') {
-                        return response()->download($response['filename'])->deleteFileAfterSend(true);
+                        return response()->streamDownload(function () use ($response) {
+                            // Langsung tembak ke output buffer browser
+                            $response['writer']->save('php://output');
+                        }, $response['filename'], [
+                            'Content-Type' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+                            'Cache-Control' => 'max-age=0',
+                        ]);
                     } else if ($response['status'] == 'error') {
                         $this->dispatch('notification', ['type' => 'warning', 'message' => $response['message']]);
                         return;
@@ -130,7 +166,13 @@ class GeneralReportController extends Component
                 if ($this->nipon == 'Infure') {
                     $response = $this->daftarProduksiPerTipeInfure($tglMasuk, $tglKeluar);
                     if ($response['status'] == 'success') {
-                        return response()->download($response['filename'])->deleteFileAfterSend(true);
+                        return response()->streamDownload(function () use ($response) {
+                            // Langsung tembak ke output buffer browser
+                            $response['writer']->save('php://output');
+                        }, $response['filename'], [
+                            'Content-Type' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+                            'Cache-Control' => 'max-age=0',
+                        ]);
                     } else if ($response['status'] == 'error') {
                         $this->dispatch('notification', ['type' => 'warning', 'message' => $response['message']]);
                         return;
@@ -138,7 +180,13 @@ class GeneralReportController extends Component
                 } else {
                     $response = $this->daftarProduksiPerTipeSeitai($tglMasuk, $tglKeluar);
                     if ($response['status'] == 'success') {
-                        return response()->download($response['filename'])->deleteFileAfterSend(true);
+                        return response()->streamDownload(function () use ($response) {
+                            // Langsung tembak ke output buffer browser
+                            $response['writer']->save('php://output');
+                        }, $response['filename'], [
+                            'Content-Type' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+                            'Cache-Control' => 'max-age=0',
+                        ]);
                     } else if ($response['status'] == 'error') {
                         $this->dispatch('notification', ['type' => 'warning', 'message' => $response['message']]);
                         return;
@@ -149,7 +197,13 @@ class GeneralReportController extends Component
                 if ($this->nipon == 'Infure') {
                     $response = $this->daftarProduksiPerProdukInfure($tglMasuk, $tglKeluar);
                     if ($response['status'] == 'success') {
-                        return response()->download($response['filename'])->deleteFileAfterSend(true);
+                        return response()->streamDownload(function () use ($response) {
+                            // Langsung tembak ke output buffer browser
+                            $response['writer']->save('php://output');
+                        }, $response['filename'], [
+                            'Content-Type' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+                            'Cache-Control' => 'max-age=0',
+                        ]);
                     } else if ($response['status'] == 'error') {
                         $this->dispatch('notification', ['type' => 'warning', 'message' => $response['message']]);
                         return;
@@ -157,7 +211,13 @@ class GeneralReportController extends Component
                 } else {
                     $response = $this->daftarProduksiPerProdukSeitai($tglMasuk, $tglKeluar);
                     if ($response['status'] == 'success') {
-                        return response()->download($response['filename'])->deleteFileAfterSend(true);
+                        return response()->streamDownload(function () use ($response) {
+                            // Langsung tembak ke output buffer browser
+                            $response['writer']->save('php://output');
+                        }, $response['filename'], [
+                            'Content-Type' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+                            'Cache-Control' => 'max-age=0',
+                        ]);
                     } else if ($response['status'] == 'error') {
                         $this->dispatch('notification', ['type' => 'warning', 'message' => $response['message']]);
                         return;
@@ -168,7 +228,13 @@ class GeneralReportController extends Component
                 if ($this->nipon == 'Infure') {
                     $response = $this->daftarProduksiPerDepartemenPerJenisInfure($tglMasuk, $tglKeluar);
                     if ($response['status'] == 'success') {
-                        return response()->download($response['filename'])->deleteFileAfterSend(true);
+                        return response()->streamDownload(function () use ($response) {
+                            // Langsung tembak ke output buffer browser
+                            $response['writer']->save('php://output');
+                        }, $response['filename'], [
+                            'Content-Type' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+                            'Cache-Control' => 'max-age=0',
+                        ]);
                     } else if ($response['status'] == 'error') {
                         $this->dispatch('notification', ['type' => 'warning', 'message' => $response['message']]);
                         return;
@@ -176,7 +242,13 @@ class GeneralReportController extends Component
                 } else {
                     $response = $this->daftarProduksiPerDepartemenPerJenisSeitai($tglMasuk, $tglKeluar);
                     if ($response['status'] == 'success') {
-                        return response()->download($response['filename'])->deleteFileAfterSend(true);
+                        return response()->streamDownload(function () use ($response) {
+                            // Langsung tembak ke output buffer browser
+                            $response['writer']->save('php://output');
+                        }, $response['filename'], [
+                            'Content-Type' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+                            'Cache-Control' => 'max-age=0',
+                        ]);
                     } else if ($response['status'] == 'error') {
                         $this->dispatch('notification', ['type' => 'warning', 'message' => $response['message']]);
                         return;
@@ -187,7 +259,13 @@ class GeneralReportController extends Component
                 if ($this->nipon == 'Infure') {
                     $response = $this->daftarProduksiPerDepartemenPerTypeInfure($tglMasuk, $tglKeluar);
                     if ($response['status'] == 'success') {
-                        return response()->download($response['filename'])->deleteFileAfterSend(true);
+                        return response()->streamDownload(function () use ($response) {
+                            // Langsung tembak ke output buffer browser
+                            $response['writer']->save('php://output');
+                        }, $response['filename'], [
+                            'Content-Type' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+                            'Cache-Control' => 'max-age=0',
+                        ]);
                     } else if ($response['status'] == 'error') {
                         $this->dispatch('notification', ['type' => 'warning', 'message' => $response['message']]);
                         return;
@@ -195,7 +273,13 @@ class GeneralReportController extends Component
                 } else {
                     $response = $this->daftarProduksiPerDepartemenPerTypeSeitai($tglMasuk, $tglKeluar);
                     if ($response['status'] == 'success') {
-                        return response()->download($response['filename'])->deleteFileAfterSend(true);
+                        return response()->streamDownload(function () use ($response) {
+                            // Langsung tembak ke output buffer browser
+                            $response['writer']->save('php://output');
+                        }, $response['filename'], [
+                            'Content-Type' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+                            'Cache-Control' => 'max-age=0',
+                        ]);
                     } else if ($response['status'] == 'error') {
                         $this->dispatch('notification', ['type' => 'warning', 'message' => $response['message']]);
                         return;
@@ -206,7 +290,13 @@ class GeneralReportController extends Component
                 if ($this->nipon == 'Infure') {
                     $response = $this->daftarProduksiPerDepartemenPerPetugasInfure($tglMasuk, $tglKeluar);
                     if ($response['status'] == 'success') {
-                        return response()->download($response['filename'])->deleteFileAfterSend(true);
+                        return response()->streamDownload(function () use ($response) {
+                            // Langsung tembak ke output buffer browser
+                            $response['writer']->save('php://output');
+                        }, $response['filename'], [
+                            'Content-Type' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+                            'Cache-Control' => 'max-age=0',
+                        ]);
                     } else if ($response['status'] == 'error') {
                         $this->dispatch('notification', ['type' => 'warning', 'message' => $response['message']]);
                         return;
@@ -214,7 +304,13 @@ class GeneralReportController extends Component
                 } else {
                     $response = $this->daftarProduksiPerDepartemenPerPetugasSeitai($tglMasuk, $tglKeluar);
                     if ($response['status'] == 'success') {
-                        return response()->download($response['filename'])->deleteFileAfterSend(true);
+                        return response()->streamDownload(function () use ($response) {
+                            // Langsung tembak ke output buffer browser
+                            $response['writer']->save('php://output');
+                        }, $response['filename'], [
+                            'Content-Type' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+                            'Cache-Control' => 'max-age=0',
+                        ]);
                     } else if ($response['status'] == 'error') {
                         $this->dispatch('notification', ['type' => 'warning', 'message' => $response['message']]);
                         return;
@@ -225,7 +321,13 @@ class GeneralReportController extends Component
                 if ($this->nipon == 'Infure') {
                     $response = $this->daftarLossPerDepartemenInfure($tglMasuk, $tglKeluar);
                     if ($response['status'] == 'success') {
-                        return response()->download($response['filename'])->deleteFileAfterSend(true);
+                        return response()->streamDownload(function () use ($response) {
+                            // Langsung tembak ke output buffer browser
+                            $response['writer']->save('php://output');
+                        }, $response['filename'], [
+                            'Content-Type' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+                            'Cache-Control' => 'max-age=0',
+                        ]);
                     } else if ($response['status'] == 'error') {
                         $this->dispatch('notification', ['type' => 'warning', 'message' => $response['message']]);
                         return;
@@ -233,7 +335,13 @@ class GeneralReportController extends Component
                 } else {
                     $response = $this->daftarLossPerDepartemenSeitai($tglMasuk, $tglKeluar);
                     if ($response['status'] == 'success') {
-                        return response()->download($response['filename'])->deleteFileAfterSend(true);
+                        return response()->streamDownload(function () use ($response) {
+                            // Langsung tembak ke output buffer browser
+                            $response['writer']->save('php://output');
+                        }, $response['filename'], [
+                            'Content-Type' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+                            'Cache-Control' => 'max-age=0',
+                        ]);
                     } else if ($response['status'] == 'error') {
                         $this->dispatch('notification', ['type' => 'warning', 'message' => $response['message']]);
                         return;
@@ -244,7 +352,13 @@ class GeneralReportController extends Component
                 if ($this->nipon == 'Infure') {
                     $response = $this->daftarLossPerDepartemenPerJenisInfure($tglMasuk, $tglKeluar);
                     if ($response['status'] == 'success') {
-                        return response()->download($response['filename'])->deleteFileAfterSend(true);
+                        return response()->streamDownload(function () use ($response) {
+                            // Langsung tembak ke output buffer browser
+                            $response['writer']->save('php://output');
+                        }, $response['filename'], [
+                            'Content-Type' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+                            'Cache-Control' => 'max-age=0',
+                        ]);
                     } else if ($response['status'] == 'error') {
                         $this->dispatch('notification', ['type' => 'warning', 'message' => $response['message']]);
                         return;
@@ -252,7 +366,13 @@ class GeneralReportController extends Component
                 } else {
                     $response = $this->daftarLossPerDepartemenPerJenisSeitai($tglMasuk, $tglKeluar);
                     if ($response['status'] == 'success') {
-                        return response()->download($response['filename'])->deleteFileAfterSend(true);
+                        return response()->streamDownload(function () use ($response) {
+                            // Langsung tembak ke output buffer browser
+                            $response['writer']->save('php://output');
+                        }, $response['filename'], [
+                            'Content-Type' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+                            'Cache-Control' => 'max-age=0',
+                        ]);
                     } else if ($response['status'] == 'error') {
                         $this->dispatch('notification', ['type' => 'warning', 'message' => $response['message']]);
                         return;
@@ -263,7 +383,13 @@ class GeneralReportController extends Component
                 if ($this->nipon == 'Infure') {
                     $response = $this->daftarLossPerPetugasInfure($tglMasuk, $tglKeluar);
                     if ($response['status'] == 'success') {
-                        return response()->download($response['filename'])->deleteFileAfterSend(true);
+                        return response()->streamDownload(function () use ($response) {
+                            // Langsung tembak ke output buffer browser
+                            $response['writer']->save('php://output');
+                        }, $response['filename'], [
+                            'Content-Type' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+                            'Cache-Control' => 'max-age=0',
+                        ]);
                     } else if ($response['status'] == 'error') {
                         $this->dispatch('notification', ['type' => 'warning', 'message' => $response['message']]);
                         return;
@@ -271,7 +397,13 @@ class GeneralReportController extends Component
                 } else {
                     $response = $this->daftarLossPerPetugasSeitai($tglMasuk, $tglKeluar);
                     if ($response['status'] == 'success') {
-                        return response()->download($response['filename'])->deleteFileAfterSend(true);
+                        return response()->streamDownload(function () use ($response) {
+                            // Langsung tembak ke output buffer browser
+                            $response['writer']->save('php://output');
+                        }, $response['filename'], [
+                            'Content-Type' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+                            'Cache-Control' => 'max-age=0',
+                        ]);
                     } else if ($response['status'] == 'error') {
                         $this->dispatch('notification', ['type' => 'warning', 'message' => $response['message']]);
                         return;
@@ -282,7 +414,13 @@ class GeneralReportController extends Component
                 if ($this->nipon == 'Infure') {
                     $response = $this->daftarLossPerMesinInfure($tglMasuk, $tglKeluar);
                     if ($response['status'] == 'success') {
-                        return response()->download($response['filename'])->deleteFileAfterSend(true);
+                        return response()->streamDownload(function () use ($response) {
+                            // Langsung tembak ke output buffer browser
+                            $response['writer']->save('php://output');
+                        }, $response['filename'], [
+                            'Content-Type' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+                            'Cache-Control' => 'max-age=0',
+                        ]);
                     } else if ($response['status'] == 'error') {
                         $this->dispatch('notification', ['type' => 'warning', 'message' => $response['message']]);
                         return;
@@ -290,7 +428,13 @@ class GeneralReportController extends Component
                 } else {
                     $response = $this->daftarLossPerMesinSeitai($tglMasuk, $tglKeluar);
                     if ($response['status'] == 'success') {
-                        return response()->download($response['filename'])->deleteFileAfterSend(true);
+                        return response()->streamDownload(function () use ($response) {
+                            // Langsung tembak ke output buffer browser
+                            $response['writer']->save('php://output');
+                        }, $response['filename'], [
+                            'Content-Type' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+                            'Cache-Control' => 'max-age=0',
+                        ]);
                     } else if ($response['status'] == 'error') {
                         $this->dispatch('notification', ['type' => 'warning', 'message' => $response['message']]);
                         return;
@@ -301,7 +445,13 @@ class GeneralReportController extends Component
             case 'Daftar Loss Per Mesin dan Jenis':
                 $response = $this->daftarLossPerMesinJenis($tglMasuk, $tglKeluar);
                 if ($response['status'] == 'success') {
-                    return response()->download($response['filename'])->deleteFileAfterSend(true);
+                    return response()->streamDownload(function () use ($response) {
+                            // Langsung tembak ke output buffer browser
+                            $response['writer']->save('php://output');
+                        }, $response['filename'], [
+                            'Content-Type' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+                            'Cache-Control' => 'max-age=0',
+                        ]);
                 } else if ($response['status'] == 'error') {
                     $this->dispatch('notification', ['type' => 'warning', 'message' => $response['message']]);
                     return;
@@ -311,7 +461,13 @@ class GeneralReportController extends Component
             case 'Daftar Kasus Loss Per Mesin dan Jenis':
                 $response = $this->daftarKasusLossPerMesinJenis($tglMasuk, $tglKeluar);
                 if ($response['status'] == 'success') {
-                    return response()->download($response['filename'])->deleteFileAfterSend(true);
+                    return response()->streamDownload(function () use ($response) {
+                            // Langsung tembak ke output buffer browser
+                            $response['writer']->save('php://output');
+                        }, $response['filename'], [
+                            'Content-Type' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+                            'Cache-Control' => 'max-age=0',
+                        ]);
                 } else if ($response['status'] == 'error') {
                     $this->dispatch('notification', ['type' => 'warning', 'message' => $response['message']]);
                     return;
@@ -322,7 +478,13 @@ class GeneralReportController extends Component
                 if ($this->nipon == 'Infure') {
                     $response = $this->kapasitasProduksiInfure($tglMasuk, $tglKeluar);
                     if ($response['status'] == 'success') {
-                        return response()->download($response['filename'])->deleteFileAfterSend(true);
+                        return response()->streamDownload(function () use ($response) {
+                            // Langsung tembak ke output buffer browser
+                            $response['writer']->save('php://output');
+                        }, $response['filename'], [
+                            'Content-Type' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+                            'Cache-Control' => 'max-age=0',
+                        ]);
                     } else if ($response['status'] == 'error') {
                         $this->dispatch('notification', ['type' => 'warning', 'message' => $response['message']]);
                         return;
@@ -330,7 +492,13 @@ class GeneralReportController extends Component
                 } else {
                     $response = $this->kapasitasProduksiSeitai($tglMasuk, $tglKeluar);
                     if ($response['status'] == 'success') {
-                        return response()->download($response['filename'])->deleteFileAfterSend(true);
+                        return response()->streamDownload(function () use ($response) {
+                            // Langsung tembak ke output buffer browser
+                            $response['writer']->save('php://output');
+                        }, $response['filename'], [
+                            'Content-Type' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+                            'Cache-Control' => 'max-age=0',
+                        ]);
                     } else if ($response['status'] == 'error') {
                         $this->dispatch('notification', ['type' => 'warning', 'message' => $response['message']]);
                         return;
@@ -341,7 +509,13 @@ class GeneralReportController extends Component
                 if ($this->nipon == 'Seitai') {
                     $response = $this->daftarProduksiPerPaletSeitai($tglMasuk, $tglKeluar);
                     if ($response['status'] == 'success') {
-                        return response()->download($response['filename'])->deleteFileAfterSend(true);
+                        return response()->streamDownload(function () use ($response) {
+                            // Langsung tembak ke output buffer browser
+                            $response['writer']->save('php://output');
+                        }, $response['filename'], [
+                            'Content-Type' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+                            'Cache-Control' => 'max-age=0',
+                        ]);
                     } else if ($response['status'] == 'error') {
                         $this->dispatch('notification', ['type' => 'warning', 'message' => $response['message']]);
                         return;
@@ -354,7 +528,13 @@ class GeneralReportController extends Component
                 if ($this->nipon == 'Infure') {
                     $response = $this->daftarProduksiPerMesinPerProdukInfure($tglMasuk, $tglKeluar);
                     if ($response['status'] == 'success') {
-                        return response()->download($response['filename'])->deleteFileAfterSend(true);
+                        return response()->streamDownload(function () use ($response) {
+                            // Langsung tembak ke output buffer browser
+                            $response['writer']->save('php://output');
+                        }, $response['filename'], [
+                            'Content-Type' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+                            'Cache-Control' => 'max-age=0',
+                        ]);
                     } else if ($response['status'] == 'error') {
                         $this->dispatch('notification', ['type' => 'warning', 'message' => $response['message']]);
                         return;
@@ -362,7 +542,13 @@ class GeneralReportController extends Component
                 } else {
                     $response = $this->daftarProduksiPerMesinPerProdukSeitai($tglMasuk, $tglKeluar);
                     if ($response['status'] == 'success') {
-                        return response()->download($response['filename'])->deleteFileAfterSend(true);
+                        return response()->streamDownload(function () use ($response) {
+                            // Langsung tembak ke output buffer browser
+                            $response['writer']->save('php://output');
+                        }, $response['filename'], [
+                            'Content-Type' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+                            'Cache-Control' => 'max-age=0',
+                        ]);
                     } else if ($response['status'] == 'error') {
                         $this->dispatch('notification', ['type' => 'warning', 'message' => $response['message']]);
                         return;
@@ -373,7 +559,13 @@ class GeneralReportController extends Component
             case 'Jam Mati Per Mesin':
                 $response = $this->jamMatiPerMesin($tglMasuk, $tglKeluar);
                 if ($response['status'] == 'success') {
-                    return response()->download($response['filename'])->deleteFileAfterSend(true);
+                    return response()->streamDownload(function () use ($response) {
+                            // Langsung tembak ke output buffer browser
+                            $response['writer']->save('php://output');
+                        }, $response['filename'], [
+                            'Content-Type' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+                            'Cache-Control' => 'max-age=0',
+                        ]);
                 } else if ($response['status'] == 'error') {
                     $this->dispatch('notification', ['type' => 'warning', 'message' => $response['message']]);
                     return;
@@ -383,7 +575,13 @@ class GeneralReportController extends Component
             case 'Jam Mati Per Jenis':
                 $response = $this->jamMatiPerJenis($tglMasuk, $tglKeluar);
                 if ($response['status'] == 'success') {
-                    return response()->download($response['filename'])->deleteFileAfterSend(true);
+                    return response()->streamDownload(function () use ($response) {
+                            // Langsung tembak ke output buffer browser
+                            $response['writer']->save('php://output');
+                        }, $response['filename'], [
+                            'Content-Type' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+                            'Cache-Control' => 'max-age=0',
+                        ]);
                 } else if ($response['status'] == 'error') {
                     $this->dispatch('notification', ['type' => 'warning', 'message' => $response['message']]);
                     return;
@@ -924,13 +1122,11 @@ class GeneralReportController extends Component
         }
 
         $writer = new Xlsx($spreadsheet);
-        $filename = 'asset/report/' . $this->nipon . '-' . $this->jenisreport . '.xlsx';
-        $writer->save($filename);
-        $response = [
-            'status' => 'success',
-            'filename' => $filename
+        return [
+            'status'   => 'success',
+            'writer'   => $writer,
+            'filename' => $this->nipon . '-' . $this->jenisReport . '.xlsx'
         ];
-        return $response;
     }
 
     public function daftarProduksiPerMesinPerProdukInfure($tglMasuk, $tglKeluar)

--- a/app/Http/Livewire/Report/ProductionLossReportController.php
+++ b/app/Http/Livewire/Report/ProductionLossReportController.php
@@ -445,11 +445,25 @@ class ProductionLossReportController extends Component
 
         $writer = new Xlsx($spreadsheet);
         if ($this->nipon == 'infure') {
-            $writer->save('asset/report/Report-Infure.xlsx');
-            return response()->download('asset/report/Report-Infure.xlsx');
+            $filename = 'Report-Infure.xlsx.xlsx';
+            return response()->streamDownload(function () use ($writer) {
+                // Data langsung ditembakkan ke buffer unduhan browser
+                $writer->save('php://output');
+            }, $filename, [
+                // Header spesifik untuk file Excel
+                'Content-Type' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+                'Cache-Control' => 'max-age=0',
+            ]);
         } else {
-            $writer->save('asset/report/Report-Seitai.xlsx');
-            return response()->download('asset/report/Report-Seitai.xlsx');
+            $filename = 'Report-Seitai.xlsx';
+            return response()->streamDownload(function () use ($writer) {
+                // Data langsung ditembakkan ke buffer unduhan browser
+                $writer->save('php://output');
+            }, $filename, [
+                // Header spesifik untuk file Excel
+                'Content-Type' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+                'Cache-Control' => 'max-age=0',
+            ]);
         }
     }
 


### PR DESCRIPTION
- Updated multiple report service classes to return the Excel writer and filename instead of saving the file to disk.
- Modified the export method in GeneralReportController and ProductionLossReportController to use streamDownload for immediate file download.
- Removed unnecessary file saving operations, improving performance and reducing disk usage.